### PR TITLE
グローバルのworkflow_rulesを追加する

### DIFF
--- a/agents.xml
+++ b/agents.xml
@@ -11,4 +11,7 @@
       - Do NOT use formal speech.
     </tone>
   </agent_profile>
+  <workflow_rules>
+    - When creating a Markdown file, run `markdownlint-cli2 --fix {target_file}` on that file.
+  </workflow_rules>
 </agents_config>


### PR DESCRIPTION
## 変更内容
- agents.xml に workflow_rules を agents_config 直下で定義

## 変更理由
Markdown作成後のlint実行ルールを全エージェント共通に適用するため

## 技術的な詳細
- agent_profile 直下ではなく agents_config 直下に移動

## 注意事項
- エージェント個別のルールとは別に解釈される前提