### PR TITLE
Add configurable export directory for blog idea draft

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,31 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: markdownlint-cli2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install markdownlint-cli2
+        run: npm install --no-save markdownlint-cli2
+
+      - name: Run markdownlint-cli2
+        run: npx markdownlint-cli2 --config .markdownlint-cli2.yaml "**/*.md"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,13 @@
+config:
+  MD013: false
+  MD041: false
+
+ignores:
+  - ".github"
+  - "**.json"
+  - "**.lua"
+  - "**.yml"
+  - "**.sh"
+  - "**.toml"
+  - "**.txt"
+  - "**/node_modules/**"

--- a/skills/blog-idea-draft-export/SKILL.md
+++ b/skills/blog-idea-draft-export/SKILL.md
@@ -1,25 +1,48 @@
 ---
 name: blog-idea-draft-export
-description: Create or update a Markdown blog draft from recent work and export it to `~/workspace/hodalog-hugo/docs/idea/` with `YYYY-MM-DD_slug.md` naming. Use when the user asks to turn completed implementation/review work into an article draft, memo, or publish-ready idea post for hodalog.
+description: Create or update a Markdown blog draft from recent work and export it with `YYYY-MM-DD_slug.md` naming. Output directory can be set via environment variable or CLI option; if missing, ask the user and pass it explicitly.
 ---
 
 # Blog Idea Draft Export
 
 ## Goal
 
-Create a clean Markdown draft from recent work context and save it under `~/workspace/hodalog-hugo/docs/idea/` with consistent naming and linted formatting.
+Create a clean Markdown draft from recent work context and save it
+with consistent naming and linted formatting.
+
+Default export helper script:
+
+- `skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh`
 
 ## Workflow
 
 1. Gather source context from the current conversation first.
-2. Supplement context only when needed (for example: changed files, PR title/body, key commands, or outcomes).
+2. Supplement context only when needed
+   (for example: changed files, PR title/body, key commands, or outcomes).
 3. Choose a short kebab-case slug.
-4. Use local date (`date +%F`) and build the filename as `YYYY-MM-DD_slug.md`.
-5. Ensure `~/workspace/hodalog-hugo/docs/idea/` exists.
-6. If the target file already exists, ask before overwriting.
-7. Write the draft in Markdown.
-8. Run `markdownlint-cli2 --fix <target_file>`.
-9. Return the output file path and a short summary of the draft structure.
+4. Draft the Markdown content in the assistant response first.
+5. Export using the helper script (content goes through stdin):
+
+```bash
+cat <<'EOF' | \
+  skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh \
+  --slug "<slug>" --output-dir "<dir>"
+# Title
+...
+EOF
+```
+
+1. Output directory resolution order:
+   1. `--output-dir <dir>`
+   2. `BLOG_IDEA_DRAFT_EXPORT_DIR` environment variable
+   3. If neither is set, ask the user which directory to use,
+      then pass `--output-dir` explicitly.
+   4. The script can show an interactive prompt only when run from a TTY.
+2. The script uses local date (`date +%F`) to build `YYYY-MM-DD_slug.md`
+   unless `--date` is specified.
+3. If the target file already exists, ask before overwriting (or use `--force`).
+4. The script runs `markdownlint-cli2 --fix <target_file>`.
+5. Return the output file path and a short summary of the draft structure.
 
 ## Draft Structure
 
@@ -67,3 +90,10 @@ Use this as the default skeleton, then adapt to the user request.
 - Keep technical details concrete (file paths, commands, settings).
 - Prefer practical lessons over long background theory.
 - Avoid adding claims that are not present in the source context.
+
+## Script Notes
+
+- Required: `--slug <kebab-case>`
+- Optional: `--output-dir <dir>`, `--date <YYYY-MM-DD>`, `--force`
+- Input: Markdown via stdin
+- Output: prints final file path

--- a/skills/blog-idea-draft-export/agents/openai.yaml
+++ b/skills/blog-idea-draft-export/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Blog Idea Draft Export"
   short_description: "Draft blog ideas and export Markdown files to hodalog docs/idea"
-  default_prompt: "Summarize recent work into a blog draft and export it to ~/workspace/hodalog-hugo/docs/idea/YYYY-MM-DD_<slug>.md."
+  default_prompt: "Summarize recent work into a blog draft, then export it via skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh using --output-dir or BLOG_IDEA_DRAFT_EXPORT_DIR. If neither is set, ask the user which directory to use."

--- a/skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh
+++ b/skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  export_blog_idea_draft.sh --slug <kebab-case> [--date <YYYY-MM-DD>] [--output-dir <dir>] [--force]
+
+Behavior:
+  - Output dir priority: --output-dir > BLOG_IDEA_DRAFT_EXPORT_DIR > interactive prompt (TTY only).
+  - Markdown content is read from stdin.
+  - File name: YYYY-MM-DD_<slug>.md
+  - Runs markdownlint-cli2 --fix after writing.
+EOF
+}
+
+prompt_from_tty() {
+  local __var_name="$1"
+  local __prompt="$2"
+  local __value=""
+
+  if [[ ! -t 0 && ! -t 1 ]]; then
+    return 1
+  fi
+
+  if read -r -p "$__prompt" __value < /dev/tty; then
+    printf -v "$__var_name" "%s" "$__value"
+    return 0
+  fi
+
+  return 1
+}
+
+slug=""
+draft_date=""
+output_dir=""
+force_overwrite="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --slug)
+      slug="${2:-}"
+      shift 2
+      ;;
+    --date)
+      draft_date="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    --force)
+      force_overwrite="1"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$slug" ]]; then
+  echo "Error: --slug is required." >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! "$slug" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "Error: slug must be kebab-case ASCII (e.g. my-post-title)." >&2
+  exit 1
+fi
+
+if [[ -z "$draft_date" ]]; then
+  draft_date="$(date +%F)"
+fi
+
+if [[ -z "$output_dir" ]]; then
+  output_dir="${BLOG_IDEA_DRAFT_EXPORT_DIR:-}"
+fi
+
+if [[ -z "$output_dir" ]]; then
+  default_dir="$HOME/workspace/hodalog-hugo/docs/idea"
+  if prompt_from_tty user_dir "Output directory (default: ${default_dir}): "; then
+    output_dir="${user_dir:-$default_dir}"
+  else
+    echo "Error: output directory is not set." >&2
+    echo "Set BLOG_IDEA_DRAFT_EXPORT_DIR or pass --output-dir." >&2
+    echo "In skill execution, ask the user for a directory and pass --output-dir." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$output_dir"
+target_file="${output_dir}/${draft_date}_${slug}.md"
+
+if [[ -e "$target_file" && "$force_overwrite" != "1" ]]; then
+  if prompt_from_tty answer "File exists: ${target_file}. Overwrite? [y/N]: "; then
+    case "$answer" in
+      y|Y|yes|YES)
+        ;;
+      *)
+        echo "Canceled."
+        exit 1
+        ;;
+    esac
+  else
+    echo "Error: target file already exists: ${target_file}" >&2
+    echo "Use --force in non-interactive mode." >&2
+    exit 1
+  fi
+fi
+
+cat > "$target_file"
+
+markdownlint-cli2 --fix "$target_file"
+
+echo "$target_file"


### PR DESCRIPTION
## 変更内容
- `skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh` を追加
- 出力先を `--output-dir` / `BLOG_IDEA_DRAFT_EXPORT_DIR` で解決するフローへ更新
- `skills/blog-idea-draft-export/SKILL.md` を新運用に合わせて更新
- `skills/blog-idea-draft-export/agents/openai.yaml` の default prompt を更新

## 変更理由
固定パス前提だと環境依存が強く、スキルの再利用性が下がるため。

## 技術的な詳細
- 解決順序: `--output-dir` > `BLOG_IDEA_DRAFT_EXPORT_DIR` > TTY対話入力
- 非対話モードで出力先未指定時はエラーを返し、呼び出し側で保存先を明示する設計
- 既存ファイル上書きは対話確認、非対話では `--force` を要求
- 保存後に `markdownlint-cli2 --fix` を自動実行

## 注意事項
- `BLOG_IDEA_DRAFT_EXPORT_DIR` に `~` を含める場合、クォート付きexportでは展開されないため正規化が必要
- 対話プロンプトはTTY環境でのみ有効

## 動作確認
- `markdownlint-cli2 --fix skills/blog-idea-draft-export/SKILL.md`
- `bash -n skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh`
- 環境変数ありでの出力成功
- 非対話モードで出力先未指定時にエラー
- 非対話モードで既存ファイル上書き時に `--force` 必須
