### PR TITLE
Add investigation subagents for Incremental Drilling pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@ CODEX_SKILLS_DEST := $(HOME)/.codex/skills
 CLAUDE_SKILLS_DEST := $(HOME)/.claude/skills
 CURSOR_SKILLS_DEST := $(HOME)/.cursor/skills
 
+AGENTS_MD_SRC := $(PWD)/agents
+CODEX_AGENTS_SRC := $(PWD)/agents/codex
+CODEX_AGENTS_DEST := $(HOME)/.codex/agents
+CODEX_CONFIG := $(HOME)/.codex/config.toml
+CLAUDE_AGENTS_DEST := $(HOME)/.claude/agents
+CURSOR_AGENTS_DEST := $(HOME)/.cursor/agents
+
 .PHONY: codex-link
 codex-link:
 	@ln -sf "$(AGENTS_SRC)" "$(AGENTS_DEST)"
@@ -106,3 +113,140 @@ claude-skills-copy:
 .PHONY: cursor-skills-copy
 cursor-skills-copy:
 	$(call copy_skills,$(CURSOR_SKILLS_DEST))
+
+define copy_agents_md
+	@set -eu; \
+	src="$(AGENTS_MD_SRC)"; \
+	dest="$(1)"; \
+	if [ ! -d "$$src" ]; then \
+		echo "Source agents directory not found: $$src"; \
+		exit 1; \
+	fi; \
+	if [ -L "$$dest" ]; then \
+		echo "Destination is a symlink. Remove it before copying: $$dest"; \
+		exit 1; \
+	fi; \
+	mkdir -p "$$dest"; \
+	tmp=$$(mktemp); \
+	trap 'rm -f "$$tmp"' EXIT; \
+	find "$$src" -maxdepth 1 -name '*.md' -type f -print0 > "$$tmp"; \
+	if [ ! -s "$$tmp" ]; then \
+		echo "No agent .md files found in $$src"; \
+		exit 0; \
+	fi; \
+	dup_found=0; \
+	dup_list=""; \
+	while IFS= read -r -d '' f; do \
+		base=$$(basename "$$f"); \
+		if [ -e "$$dest/$$base" ]; then \
+			dup_found=1; \
+			dup_list="$$dup_list$$base\n"; \
+		fi; \
+	done < "$$tmp"; \
+	overwrite=0; \
+	if [ "$$dup_found" -eq 1 ]; then \
+		echo "The following agents already exist in $$dest:"; \
+		printf "%b" "$$dup_list"; \
+		printf "Overwrite existing agents? [y/N] "; \
+		read -r ans; \
+		case "$$ans" in \
+			y|Y) overwrite=1 ;; \
+			*) overwrite=0 ;; \
+		esac; \
+	fi; \
+	while IFS= read -r -d '' f; do \
+		base=$$(basename "$$f"); \
+		if [ -e "$$dest/$$base" ] && [ "$$overwrite" -ne 1 ]; then \
+			echo "Skip $$base (already exists)"; \
+			continue; \
+		fi; \
+		cp "$$f" "$$dest/$$base"; \
+		echo "Installed $$base"; \
+	done < "$$tmp"; \
+	echo "Done."
+endef
+
+.PHONY: agents-copy
+agents-copy: codex-agents-copy claude-agents-copy cursor-agents-copy
+
+.PHONY: codex-agents-copy
+codex-agents-copy:
+	@set -eu; \
+	src="$(CODEX_AGENTS_SRC)"; \
+	dest="$(CODEX_AGENTS_DEST)"; \
+	config="$(CODEX_CONFIG)"; \
+	if [ ! -d "$$src" ]; then \
+		echo "Source Codex agents directory not found: $$src"; \
+		exit 1; \
+	fi; \
+	mkdir -p "$$dest"; \
+	tmp=$$(mktemp); \
+	trap 'rm -f "$$tmp"' EXIT; \
+	find "$$src" -maxdepth 1 -name '*.toml' -type f -print0 > "$$tmp"; \
+	if [ ! -s "$$tmp" ]; then \
+		echo "No agent .toml files found in $$src"; \
+		exit 0; \
+	fi; \
+	dup_found=0; \
+	dup_list=""; \
+	while IFS= read -r -d '' f; do \
+		base=$$(basename "$$f"); \
+		if [ -e "$$dest/$$base" ]; then \
+			dup_found=1; \
+			dup_list="$$dup_list$$base\n"; \
+		fi; \
+	done < "$$tmp"; \
+	overwrite=0; \
+	if [ "$$dup_found" -eq 1 ]; then \
+		echo "The following Codex agent configs already exist in $$dest:"; \
+		printf "%b" "$$dup_list"; \
+		printf "Overwrite existing agent configs? [y/N] "; \
+		read -r ans; \
+		case "$$ans" in \
+			y|Y) overwrite=1 ;; \
+			*) overwrite=0 ;; \
+		esac; \
+	fi; \
+	while IFS= read -r -d '' f; do \
+		base=$$(basename "$$f"); \
+		if [ -e "$$dest/$$base" ] && [ "$$overwrite" -ne 1 ]; then \
+			echo "Skip $$base (already exists)"; \
+		else \
+			cp "$$f" "$$dest/$$base"; \
+			echo "Installed $$base -> $$dest/$$base"; \
+		fi; \
+	done < "$$tmp"; \
+	echo ""; \
+	echo "--- config.toml registration ---"; \
+	if [ ! -f "$$config" ]; then \
+		echo "Warning: $$config not found. Skipping config.toml registration."; \
+		echo "You may need to manually add [agents.*] entries."; \
+		exit 0; \
+	fi; \
+	while IFS= read -r -d '' f; do \
+		base=$$(basename "$$f"); \
+		name=$${base%.toml}; \
+		section_header="[agents.$$name]"; \
+		if grep -qF "$$section_header" "$$config"; then \
+			echo "$$section_header already exists in config.toml (skipped)"; \
+		else \
+			description=""; \
+			case "$$name" in \
+				investigation-scout) description="Phase.1 investigation agent: broad scanning, returns Scout Report" ;; \
+				investigation-diver) description="Phase.2 investigation agent: deep analysis of Scout Report candidates" ;; \
+				*) description="Agent: $$name" ;; \
+			esac; \
+			printf '\n%s\ndescription = "%s"\nconfig_file = "agents/%s"\n' \
+				"$$section_header" "$$description" "$$base" >> "$$config"; \
+			echo "Added $$section_header to config.toml"; \
+		fi; \
+	done < "$$tmp"; \
+	echo "Done."
+
+.PHONY: claude-agents-copy
+claude-agents-copy:
+	$(call copy_agents_md,$(CLAUDE_AGENTS_DEST))
+
+.PHONY: cursor-agents-copy
+cursor-agents-copy:
+	$(call copy_agents_md,$(CURSOR_AGENTS_DEST))

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,6 +7,7 @@
 ## 構成
 
 - agents.xml: AGENTS.mdとCLAUDE.mdの実態。`~/.codex/AGENTS.md`または`~/.claude/CLAUDE.md`のシンボリックリンク。
+- agents/: サブエージェント定義（Claude/Cursor用Markdown、Codex CLI用TOML）。
 - Makefile: シンボリックリンクの作成と削除を簡単に実行するためのコマンドを実装。
 - skills/: Codex CLI、Claude Code、Cursorで共通利用するSkills。
 
@@ -57,6 +58,22 @@ make cursor-skills-copy
 ```sh
 make codex-skills-install
 ```
+
+エージェントをユーザーレベルディレクトリにコピーする:
+
+```sh
+make agents-copy
+```
+
+ツール別:
+
+```sh
+make codex-agents-copy
+make claude-agents-copy
+make cursor-agents-copy
+```
+
+Codex CLI の場合、`agents-copy` は `~/.codex/config.toml` への `[agents.*]` エントリ登録も行う。
 
 ## AGENTS.mdの中身をxmlとして定義する理由
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository manages my AGENTS.md file for Codex CLI, and can also generate a
 ## Structure
 
 - agents.xml: The actual content backing `AGENTS.md` and `CLAUDE.md`. Create a symlink from `~/.codex/AGENTS.md` or `~/.claude/CLAUDE.md` to this file.
-- agents/: Subagent definitions for investigation workflows (Markdown for Claude/Cursor, TOML for Codex CLI).
+- agents/: Subagent definitions (Markdown for Claude/Cursor, TOML for Codex CLI).
 - Makefile: Provides commands to create and remove the symlink(s).
 - skills/: Shared Skills for Codex CLI, Claude Code, and Cursor.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository manages my AGENTS.md file for Codex CLI, and can also generate a
 ## Structure
 
 - agents.xml: The actual content backing `AGENTS.md` and `CLAUDE.md`. Create a symlink from `~/.codex/AGENTS.md` or `~/.claude/CLAUDE.md` to this file.
+- agents/: Subagent definitions for investigation workflows (Markdown for Claude/Cursor, TOML for Codex CLI).
 - Makefile: Provides commands to create and remove the symlink(s).
 - skills/: Shared Skills for Codex CLI, Claude Code, and Cursor.
 
@@ -57,6 +58,22 @@ Legacy alias (copy for Codex only):
 ```sh
 make codex-skills-install
 ```
+
+Copy agents into user-level directories for Codex/Claude/Cursor:
+
+```sh
+make agents-copy
+```
+
+Per-tool options:
+
+```sh
+make codex-agents-copy
+make claude-agents-copy
+make cursor-agents-copy
+```
+
+For Codex CLI, `agents-copy` also registers `[agents.*]` entries in `~/.codex/config.toml`.
 
 ## Why define AGENTS.md in XML
 

--- a/agents/codex/investigation-diver.toml
+++ b/agents/codex/investigation-diver.toml
@@ -1,0 +1,62 @@
+# investigation-diver: Phase.2 Incremental Drilling agent
+# Deep analysis of high-priority candidates from Scout Reports
+# Claude/Cursor equivalent: agents/investigation-diver.md
+# Note: Claude/Cursor version has memory=project for cross-session learning.
+# Codex CLI does not support agent-level memory, so memory instructions are omitted.
+
+model = "gpt-5.3-codex"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are an investigation diver. Your role is Phase.2 of the Incremental Drilling pattern: take the Scout Report(s) from Phase.1 and dig deep into the high-priority candidates with rigorous, evidence-based analysis.
+
+## Constraints
+
+- You are limited to READ-ONLY operations. Do not modify any files.
+- Equivalent tool restrictions: Read, Grep, Glob only.
+
+## Your mission
+
+When given one or more Scout Reports:
+
+1. **Prioritize** — focus on High-priority candidates first, then Medium if time allows
+2. **Read deeply** — trace call chains, inspect logic, cross-reference related files
+3. **Cite evidence** — every claim must reference a specific file and line number
+4. **Challenge yourself** — actively look for counterevidence; note what you could NOT confirm
+
+## Rules
+
+- **Evidence over intuition.** If you cannot cite a line number, do not assert it as fact.
+- **No fixes.** You are read-only. Never suggest code changes inline; only note them in Recommended Actions.
+- **Handle multiple Scout Reports.** When receiving reports from parallel scouts (Layered Delegation), synthesize across all domains before diving — look for cross-cutting patterns.
+
+## Output format
+
+Always end your response with a Diver Report in exactly this format:
+
+---
+
+## Diver Report
+
+### 結論
+
+(Core finding in 1–3 sentences. Be direct.)
+
+### 根拠
+
+- `path/to/file:line` — (quoted snippet or description, and why it matters)
+- `path/to/file:line` — (another piece of evidence)
+
+### 反証・限界
+
+- (What you could NOT confirm, or what evidence would refute the conclusion)
+- (Scope limitations: what was out of bounds for this investigation)
+
+### 推奨アクション
+
+- [ ] (Concrete next step — specific file, function, or test to look at)
+- [ ] (Another actionable item)
+
+---
+"""

--- a/agents/codex/investigation-scout.toml
+++ b/agents/codex/investigation-scout.toml
@@ -1,0 +1,59 @@
+# investigation-scout: Phase.1 Incremental Drilling agent
+# Broadly scans codebase, returns structured Scout Report
+# Claude/Cursor equivalent: agents/investigation-scout.md
+
+model = "gpt-5.3-codex"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are an investigation scout. Your role is Phase.1 of the Incremental Drilling pattern: scan broadly and shallowly to map the territory, then hand off a structured report to a deeper investigator.
+
+## Constraints
+
+- You are limited to READ-ONLY operations. Do not modify any files.
+- Equivalent tool restrictions: Read, Grep, Glob only.
+
+## Your mission
+
+When given an investigation target:
+
+1. Understand the overall structure — directory layout, module boundaries, key entry points
+2. Search for signals related to the target (patterns, symbols, file names, config)
+3. Identify candidates that warrant deeper investigation — but do NOT read deeply into them
+4. Rank candidates by priority based on surface-level evidence
+5. Propose concrete Phase.2 queries for the diver
+
+## Rules
+
+- **Breadth over depth.** Skim; do not analyze. Stop reading a file once you have enough to judge its relevance.
+- **No speculation.** Only list candidates you have actual evidence for.
+- **No fixes.** You are read-only. Never suggest code changes.
+- **Compact output.** The Scout Report must be concise enough to pass to the next agent without bloating the main conversation.
+
+## Output format
+
+Always end your response with a Scout Report in exactly this format:
+
+---
+
+## Scout Report
+
+### 調査概要
+
+(What you investigated, in 1–3 sentences)
+
+### 候補リスト（優先度順）
+
+| 優先度 | ファイル / モジュール | 根拠 |
+| ------ | --------------------- | ---- |
+| High   | path/to/file.ts       | (why this is suspicious) |
+| Medium | path/to/other.ts      | (brief reason) |
+
+### 推奨 Phase.2 クエリ
+
+- (Specific question or angle for the diver to investigate)
+- (Another specific angle)
+
+---
+"""

--- a/agents/investigation-diver.md
+++ b/agents/investigation-diver.md
@@ -1,0 +1,76 @@
+---
+name: investigation-diver
+description: "Phase.2 investigation agent for Incremental Drilling. Takes one or more Scout Reports from investigation-scout and performs deep, evidence-based analysis on high-priority candidates. Also handles Layered Delegation by accepting multiple Scout Reports in parallel. Use after investigation-scout completes Phase.1."
+tools: Read, Grep, Glob
+model: sonnet
+permissionMode: plan
+memory: project
+---
+
+You are an investigation diver. Your role is Phase.2 of the Incremental Drilling pattern: take the Scout Report(s) from Phase.1 and dig deep into the high-priority candidates with rigorous, evidence-based analysis.
+
+## Your mission
+
+When given one or more Scout Reports:
+
+1. **Load your memory** — check your agent memory for any prior findings on this codebase or related areas before starting
+2. **Prioritize** — focus on High-priority candidates first, then Medium if time allows
+3. **Read deeply** — trace call chains, inspect logic, cross-reference related files
+4. **Cite evidence** — every claim must reference a specific file and line number
+5. **Challenge yourself** — actively look for counterevidence; note what you could NOT confirm
+6. **Update your memory** — after analysis, record key findings, file paths, and architectural insights
+
+## Rules
+
+- **Evidence over intuition.** If you cannot cite a line number, do not assert it as fact.
+- **No fixes.** You are read-only. Never suggest code changes inline; only note them in Recommended Actions.
+- **Handle multiple Scout Reports.** When receiving reports from parallel scouts (Layered Delegation), synthesize across all domains before diving — look for cross-cutting patterns.
+- **Memory discipline.** Write concise, structured notes to memory. Avoid dumping raw file contents. Focus on patterns, architectural decisions, and recurring issues.
+
+## Memory format
+
+When updating memory, write to `MEMORY.md` using this structure:
+
+```markdown
+# Investigation Memory
+
+## Codebase Patterns
+- (Recurring patterns observed across investigations)
+
+## Key Files
+- `path/to/file`: (what it does, why it matters)
+
+## Past Findings
+### YYYY-MM-DD: (investigation topic)
+- (Key conclusion)
+- (Caveats / what was not confirmed)
+```
+
+## Output format
+
+Always end your response with a Diver Report in exactly this format:
+
+---
+
+## Diver Report
+
+### 結論
+
+(Core finding in 1–3 sentences. Be direct.)
+
+### 根拠
+
+- `path/to/file:line` — (quoted snippet or description, and why it matters)
+- `path/to/file:line` — (another piece of evidence)
+
+### 反証・限界
+
+- (What you could NOT confirm, or what evidence would refute the conclusion)
+- (Scope limitations: what was out of bounds for this investigation)
+
+### 推奨アクション
+
+- [ ] (Concrete next step — specific file, function, or test to look at)
+- [ ] (Another actionable item)
+
+---

--- a/agents/investigation-scout.md
+++ b/agents/investigation-scout.md
@@ -39,10 +39,10 @@ Always end your response with a Scout Report in exactly this format:
 
 ### 候補リスト（優先度順）
 
-| 優先度 | ファイル / モジュール | 根拠 |
-| ------ | --------------------- | ---- |
+| 優先度 | ファイル / モジュール | 根拠                     |
+| ------ | --------------------- | ------------------------ |
 | High   | path/to/file.ts       | (why this is suspicious) |
-| Medium | path/to/other.ts      | (brief reason) |
+| Medium | path/to/other.ts      | (brief reason)           |
 
 ### 推奨 Phase.2 クエリ
 

--- a/agents/investigation-scout.md
+++ b/agents/investigation-scout.md
@@ -1,0 +1,52 @@
+---
+name: investigation-scout
+description: "Phase.1 investigation agent for Incremental Drilling. Broadly and shallowly scans a codebase to identify candidate files and modules, then returns a structured Scout Report. Use this first when investigating an unfamiliar codebase or problem area."
+tools: Read, Grep, Glob
+model: sonnet
+permissionMode: plan
+---
+
+You are an investigation scout. Your role is Phase.1 of the Incremental Drilling pattern: scan broadly and shallowly to map the territory, then hand off a structured report to a deeper investigator.
+
+## Your mission
+
+When given an investigation target:
+
+1. Understand the overall structure — directory layout, module boundaries, key entry points
+2. Search for signals related to the target (patterns, symbols, file names, config)
+3. Identify candidates that warrant deeper investigation — but do NOT read deeply into them
+4. Rank candidates by priority based on surface-level evidence
+5. Propose concrete Phase.2 queries for the diver
+
+## Rules
+
+- **Breadth over depth.** Skim; do not analyze. Stop reading a file once you have enough to judge its relevance.
+- **No speculation.** Only list candidates you have actual evidence for.
+- **No fixes.** You are read-only. Never suggest code changes.
+- **Compact output.** The Scout Report must be concise enough to pass to the next agent without bloating the main conversation.
+
+## Output format
+
+Always end your response with a Scout Report in exactly this format:
+
+---
+
+## Scout Report
+
+### 調査概要
+
+(What you investigated, in 1–3 sentences)
+
+### 候補リスト（優先度順）
+
+| 優先度 | ファイル / モジュール | 根拠 |
+| ------ | --------------------- | ---- |
+| High   | path/to/file.ts       | (why this is suspicious) |
+| Medium | path/to/other.ts      | (brief reason) |
+
+### 推奨 Phase.2 クエリ
+
+- (Specific question or angle for the diver to investigate)
+- (Another specific angle)
+
+---

--- a/docs/log/2026-02-23_incremental-drilling-and-agents-copy.md
+++ b/docs/log/2026-02-23_incremental-drilling-and-agents-copy.md
@@ -1,0 +1,59 @@
+# Log
+
+2026-02-23: 調査用サブエージェントのレビュー・修正、agents-copy make ターゲットの実装、agent-codex-convert スキルの作成。
+
+## Summary
+
+- investigation-scout / investigation-diver サブエージェントのレビューと修正
+- `make agents-copy` ターゲットの実装（Claude/Cursor/Codex CLI 対応）
+- Codex CLI 用 TOML エージェントファイルの作成
+- `agent-codex-convert` スキルの作成（MD → TOML 自動変換）
+
+## Details
+
+### サブエージェントレビュー・修正
+
+- 公式ドキュメントとプランを照らし合わせてレビュー実施
+- 修正 4 点:
+  - `investigation-scout.md`: model を opus → sonnet に変更
+  - `investigation-scout.md`: `permissionMode: plan` を追加
+  - `investigation-diver.md`: `permissionMode: plan` を追加
+  - `investigation-diver.md`: `memory: project` を追加
+- PR #11 としてドラフト PR 作成済み
+
+### agents-copy make ターゲット
+
+- Makefile に 4 つの新規ターゲットを追加:
+  - `agents-copy`: 全ツール一括コピー
+  - `claude-agents-copy`: `~/.claude/agents/` に .md コピー
+  - `cursor-agents-copy`: `~/.cursor/agents/` に .md コピー
+  - `codex-agents-copy`: `~/.codex/agents/` に .toml コピー + `config.toml` 登録
+- `copy_agents_md` define を作成（`copy_skills` と同じ重複チェック・上書き確認パターン）
+- Codex 用は TOML コピー + `config.toml` の `[agents.*]` セクション追記を実装
+- README.md / README.ja.md にドキュメント追加
+
+### Codex CLI 用 TOML ファイル
+
+- `agents/codex/investigation-scout.toml` を作成
+- `agents/codex/investigation-diver.toml` を作成
+- 変換ルール:
+  - model: sonnet → `gpt-5.3-codex`
+  - permissionMode: plan → `sandbox_mode = "read-only"`
+  - tools → `## Constraints` セクションとして body に注入
+  - memory → Codex 非対応のためプロンプトから削除 + コメントで注記
+
+### agent-codex-convert スキル
+
+- `skills/agent-codex-convert/SKILL.md` を作成（`disable-model-invocation: true`）
+- `skills/agent-codex-convert/scripts/convert_agent_to_codex.sh` を作成
+- スクリプト機能:
+  - YAML frontmatter 解析 → TOML 自動生成
+  - `--dry-run`, `--force`, `--reasoning-effort`, `--output-dir` オプション
+  - memory フィールド検出時の WARNING 出力（手動レビュー前提）
+  - エラーハンドリング（不正入力、重複ファイル、frontmatter 欠落）
+- 既存 TOML との diff 比較で動作確認済み
+
+### 作成したプラン文書
+
+- `docs/plan/2026-02-23_agents-copy-make-targets.md`
+- `docs/plan/2026-02-23_agent-codex-convert-skill.md`

--- a/docs/plan/2026-02-21_incremental-drilling-subagents.md
+++ b/docs/plan/2026-02-21_incremental-drilling-subagents.md
@@ -1,0 +1,173 @@
+# Plan
+
+Incremental Drilling パターンを2つのカスタムSubagentで実現する。
+Phase.1（広く浅く）と Phase.2（狭く深く）を独立したコンテキストで動かすことで、
+調査ごとにメインコンテキストを汚染せず、再利用性の高い調査基盤を作る。
+
+## Scope
+
+- In:
+  - `~/.claude/agents/` への Phase.1/Phase.2 subagent ファイル作成
+  - 両 Agent の system prompt 設計（読み取り専用ツールに限定）
+  - オーケストレーション手順のドキュメント化
+- Out:
+  - スキル（`.claude/skills/`）の作成
+  - MCP サーバーの追加
+  - Phase.1 → Phase.2 の自動連携（サブエージェントはサブエージェントを生成不可のため、
+    メイン会話がオーケストレーターを担う）
+
+## Subagent 設計
+
+### Phase.1: `investigation-scout`
+
+広く・浅く・速く調査し、候補リストを返す。
+
+```yaml
+name: investigation-scout
+model: haiku          # 速度・コスト優先
+tools: Read, Grep, Glob
+permissionMode: plan  # 読み取り専用を強制
+```
+
+System prompt の責務:
+
+- 仮説なしで全体構造を把握する
+- 怪しいファイル・モジュールを列挙する（深読みしない）
+- 出力を**構造化 Markdown**（候補リスト + 優先度）で返す
+
+出力フォーマット（Agent が必ず従う）:
+
+```markdown
+## Scout Report
+
+### 調査概要
+<何を調べたか 1〜3 文>
+
+### 候補リスト（優先度順）
+| 優先度 | ファイル/モジュール | 根拠 |
+|--------|---------------------|------|
+| High   | src/foo/bar.ts      | ...  |
+
+### 推奨 Phase.2 クエリ
+- <具体的な深掘り観点 1>
+- <具体的な深掘り観点 2>
+```
+
+### Phase.2: `investigation-diver`
+
+Phase.1 の Scout Report を入力とし、候補を深く分析する。
+**複数 Scout の Report をまとめて受け取ることも可能**（Layered Delegation 拡張時）。
+
+```yaml
+name: investigation-diver
+model: sonnet         # 推論品質優先
+tools: Read, Grep, Glob
+permissionMode: plan  # 読み取り専用を強制
+memory: project       # 調査ナレッジをプロジェクト単位で蓄積
+```
+
+System prompt の責務:
+
+- Scout Report の候補リストと推奨クエリを起点にする
+- 根拠コードを引用し、証拠ベースで結論を出す
+- 反証（否定できる点）も必ず記述する
+
+出力フォーマット（Agent が必ず従う）:
+
+```markdown
+## Diver Report
+
+### 結論
+<1〜3 文で核心を述べる>
+
+### 根拠
+- `ファイル:行番号` — <引用と説明>
+
+### 反証・限界
+- <この調査で確認できなかった点>
+
+### 推奨アクション
+- [ ] <次にやるべき具体的な作業>
+```
+
+## オーケストレーション手順
+
+サブエージェントはサブエージェントを生成できないため、
+メイン会話が以下の順序でオーケストレーターを担う。
+
+### 基本パターン（Scout × 1）
+
+```text
+1. ユーザー → メイン会話: 調査依頼
+2. メイン会話 → investigation-scout: Phase.1 実行
+3. investigation-scout → メイン会話: Scout Report 返却
+4. メイン会話 → investigation-diver: Phase.2 実行（Scout Report を渡す）
+5. investigation-diver → メイン会話: Diver Report 返却
+6. メイン会話 → ユーザー: 統合サマリー提示
+```
+
+呼び出しテンプレート:
+
+```text
+# Phase.1
+Use the investigation-scout subagent to broadly investigate [調査対象].
+
+# Phase.2（Scout Report をそのまま渡す）
+Use the investigation-diver subagent. Here is the Scout Report from Phase.1:
+[Scout Report の内容]
+Deep dive into the High-priority candidates.
+```
+
+### Layered Delegation 拡張（Scout を並列起動）
+
+調査対象が広い場合、ドメインを分割して Scout を並列起動し、
+複数の Scout Report を Diver に一括で渡す。
+
+```text
+1. ユーザー → メイン会話: 広域調査依頼
+2. メイン会話 → investigation-scout × N（並列）: ドメイン別 Phase.1
+   例: Scout-A（認証モジュール）/ Scout-B（DB層）/ Scout-C（API層）
+3. 各 scout → メイン会話: Scout Report × N 返却
+4. メイン会話 → investigation-diver: 全 Scout Report を統合して Phase.2
+5. investigation-diver → メイン会話: 統合 Diver Report 返却
+```
+
+呼び出しテンプレート:
+
+```text
+# Phase.1（並列）
+Use three investigation-scout subagents in parallel:
+- Scout A: investigate the authentication module in [path]
+- Scout B: investigate the database layer in [path]
+- Scout C: investigate the API layer in [path]
+
+# Phase.2（全 Report を結合して渡す）
+Use the investigation-diver subagent. Here are Scout Reports from Phase.1:
+
+## Scout A Report（認証モジュール）
+[Scout A の出力]
+
+## Scout B Report（DB層）
+[Scout B の出力]
+
+## Scout C Report（API層）
+[Scout C の出力]
+
+Synthesize all reports and deep dive into cross-cutting High-priority candidates.
+```
+
+## Action items
+
+- [ ] `~/.claude/agents/` ディレクトリを作成する
+- [ ] `investigation-scout.md` を作成する（frontmatter + system prompt）
+- [ ] `investigation-diver.md` を作成する（frontmatter + system prompt）
+- [ ] `/agents` コマンドでロード確認する
+- [ ] サンプル調査で動作検証する（TATSU リポジトリを対象に試す）
+
+## 決定済み事項
+
+| 項目 | 決定 |
+| ---- | ---- |
+| Scout Report のサイズ問題 | 今回は考慮しない（一時ファイル方式は将来の拡張） |
+| Diver の memory | `memory: project` を付けてナレッジ蓄積する |
+| 並列 Scout 拡張 | Layered Delegation パターンを実装に含める |

--- a/docs/plan/2026-02-23_agent-codex-convert-skill.md
+++ b/docs/plan/2026-02-23_agent-codex-convert-skill.md
@@ -1,0 +1,26 @@
+# Plan
+
+`agents/*.md`（Claude/Cursor 用）から `agents/codex/*.toml`（Codex CLI 用）への
+変換を自動化するスキルを作成し、新しいエージェント追加時の手間とミスを減らす。
+既存の `blog-idea-draft-export`（SKILL.md + scripts/）パターンに従う。
+
+## Scope
+
+- In:
+  - `skills/agent-codex-convert/SKILL.md` の作成
+  - `skills/agent-codex-convert/scripts/convert_agent_to_codex.sh` の作成
+- Out:
+  - 既存の `agents/codex/*.toml` の変更
+  - Makefile の変更
+
+## Action items
+
+- [ ] `skills/agent-codex-convert/scripts/convert_agent_to_codex.sh` を作成する
+- [ ] `skills/agent-codex-convert/SKILL.md` を作成する
+- [ ] `--dry-run` で既存 TOML と diff 比較する
+- [ ] `--force` でファイル生成を確認する
+- [ ] 2 回目実行で上書き確認プロンプトを確認する
+
+## Open questions
+
+- なし

--- a/docs/plan/2026-02-23_agents-copy-make-targets.md
+++ b/docs/plan/2026-02-23_agents-copy-make-targets.md
@@ -1,0 +1,70 @@
+# Plan
+
+`agents/` のサブエージェントファイルを Claude Code, Cursor, Codex CLI の
+ユーザーレベルディレクトリへコピーする make コマンドを実装する。
+Claude/Cursor は Markdown をそのままコピー、
+Codex CLI は TOML 形式への変換が必要なため専用ファイルを用意する。
+
+## Scope
+
+- In:
+  - Makefile への agents-copy ターゲット追加（全ツール対応）
+  - Codex CLI 用 TOML エージェントファイルの作成（`agents/codex/`）
+  - README.md / README.ja.md のドキュメント更新
+- Out:
+  - 既存の link / skills-copy ターゲットの変更
+  - Codex CLI の config.toml 自体の新規生成
+
+## Codex CLI のサブエージェント配置方式
+
+Codex CLI は `~/.codex/config.toml` の `[agents.<name>]` セクションで定義する。
+
+```toml
+# ~/.codex/config.toml に追記
+[agents.investigation-scout]
+description = "Phase.1 investigation agent: broad scanning, returns Scout Report"
+config_file = "agents/investigation-scout.toml"
+```
+
+```toml
+# ~/.codex/agents/investigation-scout.toml
+model = "gpt-5.3-codex"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "..."
+```
+
+### Claude/Cursor との対応表
+
+| 機能 | Claude/Cursor | Codex CLI |
+| --- | --- | --- |
+| ファイル形式 | Markdown + YAML frontmatter | TOML |
+| 配置先 | `~/.claude/agents/`, `~/.cursor/agents/` | `~/.codex/agents/` + `config.toml` 登録 |
+| model: sonnet | そのまま | `gpt-5.3-codex` |
+| permissionMode: plan | そのまま | `sandbox_mode = "read-only"` |
+| memory: project | そのまま | 非対応（プロンプトから削除） |
+| tools 制限 | frontmatter で指定 | 非対応（developer_instructions に記述） |
+
+## Action items
+
+- [ ] `agents/codex/investigation-scout.toml` を作成する
+- [ ] `agents/codex/investigation-diver.toml` を作成する（memory 関連の記述は除外）
+- [ ] Makefile に新規変数を追加する（AGENTS_MD_SRC, CODEX_AGENTS_SRC 等）
+- [ ] Makefile に `copy_agents_md` define を追加する（Claude/Cursor 用）
+- [ ] Makefile に `codex-agents-copy` ターゲットを追加する（TOML コピー + config.toml 登録）
+- [ ] Makefile に `claude-agents-copy`, `cursor-agents-copy`, `agents-copy` ターゲットを追加する
+- [ ] README.md / README.ja.md に agents-copy セクションを追加する
+- [ ] 動作検証する
+
+## 新規ターゲット一覧
+
+| ターゲット | 動作 |
+| --- | --- |
+| `agents-copy` | 全ツール向け一括コピー |
+| `claude-agents-copy` | `agents/*.md` → `~/.claude/agents/` |
+| `cursor-agents-copy` | `agents/*.md` → `~/.cursor/agents/` |
+| `codex-agents-copy` | `agents/codex/*.toml` → `~/.codex/agents/` + `config.toml` 登録 |
+
+## Open questions
+
+- なし（Codex モデルは gpt-5.3-codex に決定済み）

--- a/skills/agent-codex-convert/SKILL.md
+++ b/skills/agent-codex-convert/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: agent-codex-convert
+description: Convert Claude/Cursor markdown subagent files to Codex CLI TOML format. Parses YAML frontmatter and body, applies model/permission/tool mappings, and outputs to agents/codex/<name>.toml.
+disable-model-invocation: true
+---
+
+# Agent Codex Convert
+
+## Goal
+
+Convert one or more Claude/Cursor agent markdown files (in `agents/`)
+to Codex CLI TOML format (in `agents/codex/`) using the helper script.
+
+Default conversion helper script:
+
+- `skills/agent-codex-convert/scripts/convert_agent_to_codex.sh`
+
+## Workflow
+
+1. Identify which agent markdown files need conversion.
+2. Run the helper script for each file (or pass multiple).
+3. Review the generated TOML file(s) for correctness.
+4. If the source had `memory:` field, review the body for remaining
+   memory-related instructions that may need manual removal.
+5. After conversion, optionally update the Makefile `codex-agents-copy`
+   case statement if a new agent name was added.
+
+## Usage
+
+Single file:
+
+```bash
+skills/agent-codex-convert/scripts/convert_agent_to_codex.sh agents/my-agent.md
+```
+
+Multiple files:
+
+```bash
+skills/agent-codex-convert/scripts/convert_agent_to_codex.sh agents/*.md
+```
+
+With options:
+
+```bash
+skills/agent-codex-convert/scripts/convert_agent_to_codex.sh \
+  --reasoning-effort high \
+  --output-dir agents/codex \
+  --force \
+  agents/investigation-diver.md
+```
+
+Preview without writing:
+
+```bash
+skills/agent-codex-convert/scripts/convert_agent_to_codex.sh \
+  --dry-run agents/my-agent.md
+```
+
+## Script Options
+
+- Positional: one or more `.md` file paths (required)
+- `--reasoning-effort <low|medium|high>`: Override default `medium`
+- `--output-dir <dir>`: Override default `agents/codex`
+- `--force`: Overwrite existing TOML without prompting
+- `--dry-run`: Print to stdout instead of writing files
+- `-h, --help`: Show usage
+
+## Conversion Mapping
+
+| Source (frontmatter) | Target (TOML) | Notes |
+| --- | --- | --- |
+| model: sonnet/opus/haiku/inherit | `model = "gpt-5.3-codex"` | All map to same model |
+| (default) | `model_reasoning_effort = "medium"` | Overridable via CLI |
+| permissionMode: plan | `sandbox_mode = "read-only"` | Other modes omitted |
+| tools | Constraints section in body | Injected before first heading |
+| memory | Comment + WARNING | Codex unsupported; review body |
+| description | Header comment | Truncated to first sentence |
+| maxTurns, background | Comment only | Codex unsupported |
+
+## Post-Conversion Checklist
+
+- [ ] Verify `developer_instructions` reads naturally
+- [ ] If memory was present, confirm memory-related paragraphs/sections removed
+- [ ] Check Constraints section matches the original tool restrictions
+- [ ] Verify no TOML-breaking characters in the body
+- [ ] If new agent, add case entry to Makefile `codex-agents-copy` target

--- a/skills/agent-codex-convert/scripts/convert_agent_to_codex.sh
+++ b/skills/agent-codex-convert/scripts/convert_agent_to_codex.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  convert_agent_to_codex.sh [OPTIONS] FILE [FILE ...]
+
+Convert Claude/Cursor agent markdown files to Codex CLI TOML format.
+
+Options:
+  --reasoning-effort <low|medium|high>  Model reasoning effort (default: medium)
+  --output-dir <dir>                    Output directory (default: agents/codex)
+  --force                               Overwrite without prompting
+  --dry-run                             Print to stdout, don't write files
+  -h, --help                            Show this help
+EOF
+}
+
+prompt_from_tty() {
+  local __var_name="$1"
+  local __prompt="$2"
+  local __value=""
+
+  if [[ ! -t 0 && ! -t 1 ]]; then
+    return 1
+  fi
+
+  if read -r -p "$__prompt" __value < /dev/tty; then
+    printf -v "$__var_name" "%s" "$__value"
+    return 0
+  fi
+
+  return 1
+}
+
+# --- Argument parsing ---
+reasoning_effort="medium"
+output_dir="agents/codex"
+force_overwrite=0
+dry_run=0
+files=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reasoning-effort)
+      reasoning_effort="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    --force)
+      force_overwrite=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      files+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "Error: at least one .md file is required." >&2
+  usage >&2
+  exit 1
+fi
+
+case "$reasoning_effort" in
+  low|medium|high) ;;
+  *)
+    echo "Error: --reasoning-effort must be low, medium, or high." >&2
+    exit 1
+    ;;
+esac
+
+# --- Main loop ---
+success_count=0
+
+for input_file in "${files[@]}"; do
+
+  # Validate input
+  if [[ ! -f "$input_file" ]]; then
+    echo "Error: File not found: $input_file" >&2
+    continue
+  fi
+  if [[ "$input_file" != *.md ]]; then
+    echo "Error: Not a .md file: $input_file" >&2
+    continue
+  fi
+
+  # Find frontmatter delimiters
+  first_delim=0
+  second_delim=0
+  line_num=0
+  while IFS= read -r line; do
+    line_num=$((line_num + 1))
+    if [[ "$line" == "---" ]]; then
+      if [[ $first_delim -eq 0 ]]; then
+        first_delim=$line_num
+      elif [[ $second_delim -eq 0 ]]; then
+        second_delim=$line_num
+        break
+      fi
+    fi
+  done < "$input_file"
+
+  if [[ $first_delim -ne 1 || $second_delim -eq 0 ]]; then
+    echo "Error: Invalid frontmatter in $input_file" >&2
+    continue
+  fi
+
+  # Parse frontmatter
+  name=""
+  description=""
+  tools=""
+  model=""
+  permission_mode=""
+  memory=""
+  max_turns=""
+  background=""
+
+  frontmatter_text=$(sed -n "2,$((second_delim - 1))p" "$input_file")
+  while IFS= read -r fm_line; do
+    [[ -z "$fm_line" || "$fm_line" == \#* ]] && continue
+
+    key="${fm_line%%:*}"
+    value="${fm_line#*: }"
+    # Strip surrounding quotes
+    value="${value#\"}"
+    value="${value%\"}"
+
+    case "$key" in
+      name)           name="$value" ;;
+      description)    description="$value" ;;
+      tools)          tools="$value" ;;
+      model)          model="$value" ;;
+      permissionMode) permission_mode="$value" ;;
+      memory)         memory="$value" ;;
+      maxTurns)       max_turns="$value" ;;
+      background)     background="$value" ;;
+      *)              echo "Warning: Unknown frontmatter key '$key' in $input_file" >&2 ;;
+    esac
+  done <<< "$frontmatter_text"
+
+  if [[ -z "$name" ]]; then
+    echo "Error: Missing 'name' in frontmatter: $input_file" >&2
+    continue
+  fi
+  if [[ -z "$description" ]]; then
+    echo "Error: Missing 'description' in frontmatter: $input_file" >&2
+    continue
+  fi
+
+  # Extract body (everything after closing ---)
+  body=$(tail -n +"$((second_delim + 1))" "$input_file")
+  # Strip leading empty lines
+  body=$(printf '%s' "$body" | sed '/./,$!d')
+
+  # Build Constraints section
+  constraints_section=""
+  if [[ "$permission_mode" == "plan" || -n "$tools" ]]; then
+    constraints_section="## Constraints"$'\n'$'\n'
+    if [[ "$permission_mode" == "plan" ]]; then
+      constraints_section+="- You are limited to READ-ONLY operations. Do not modify any files."$'\n'
+    fi
+    if [[ -n "$tools" ]]; then
+      constraints_section+="- Equivalent tool restrictions: ${tools} only."$'\n'
+    fi
+  fi
+
+  # Inject Constraints before the first ## heading in body
+  if [[ -n "$constraints_section" ]]; then
+    first_heading_line=$(printf '%s' "$body" | grep -n '^## ' | head -1 | cut -d: -f1)
+    if [[ -n "$first_heading_line" ]]; then
+      opening=$(printf '%s' "$body" | head -n "$((first_heading_line - 1))")
+      rest=$(printf '%s' "$body" | tail -n +"$first_heading_line")
+      body="${opening}"$'\n'$'\n'"${constraints_section}"$'\n'"${rest}"
+    else
+      body="${constraints_section}"$'\n'"${body}"
+    fi
+  fi
+
+  # Map sandbox_mode
+  sandbox_line=""
+  if [[ "$permission_mode" == "plan" ]]; then
+    sandbox_line='sandbox_mode = "read-only"'
+  fi
+
+  # Build header comments
+  short_desc=$(printf '%s' "$description" | sed 's/\. .*//' | cut -c1-80)
+  source_basename=$(basename "$input_file")
+
+  # Build comment block
+  comments="# ${name}: ${short_desc}"$'\n'
+  comments+="# Claude/Cursor equivalent: agents/${source_basename}"
+
+  if [[ -n "$memory" ]]; then
+    comments+=$'\n'"# Note: Claude/Cursor version has memory=${memory} for cross-session learning."
+    comments+=$'\n'"# Codex CLI does not support agent-level memory, so memory instructions are omitted."
+  fi
+  if [[ -n "$max_turns" ]]; then
+    comments+=$'\n'"# Note: Claude/Cursor version has maxTurns=${max_turns}. Codex CLI does not support this."
+  fi
+  if [[ -n "$background" ]]; then
+    comments+=$'\n'"# Note: Claude/Cursor version has background=${background}. Codex CLI does not support this."
+  fi
+
+  # Escape triple quotes in body
+  safe_body=$(printf '%s' "$body" | sed 's/"""/""\\"/g')
+
+  # Assemble TOML
+  assemble_toml() {
+    printf '%s\n' "$comments"
+    printf '\n'
+    printf 'model = "%s"\n' "gpt-5.3-codex"
+    printf 'model_reasoning_effort = "%s"\n' "$reasoning_effort"
+    if [[ -n "$sandbox_line" ]]; then
+      printf '%s\n' "$sandbox_line"
+    fi
+    printf '\n'
+    printf 'developer_instructions = """\n'
+    printf '%s\n' "$safe_body"
+    printf '"""\n'
+  }
+
+  # Output
+  if [[ $dry_run -eq 1 ]]; then
+    assemble_toml
+    if [[ -n "$memory" ]]; then
+      echo "" >&2
+      echo "[REVIEW NEEDED] Source had memory=${memory}. Memory-related sections may need manual removal from developer_instructions." >&2
+    fi
+    success_count=$((success_count + 1))
+    continue
+  fi
+
+  mkdir -p "$output_dir"
+  target_file="${output_dir}/${name}.toml"
+
+  if [[ -e "$target_file" && $force_overwrite -ne 1 ]]; then
+    if prompt_from_tty answer "File exists: ${target_file}. Overwrite? [y/N]: "; then
+      case "$answer" in
+        y|Y|yes|YES) ;;
+        *)
+          echo "Skipped: $target_file"
+          continue
+          ;;
+      esac
+    else
+      echo "Error: target file already exists: ${target_file}" >&2
+      echo "Use --force in non-interactive mode." >&2
+      continue
+    fi
+  fi
+
+  assemble_toml > "$target_file"
+  echo "Created: $target_file"
+
+  if [[ -n "$memory" ]]; then
+    echo "  WARNING: Source had memory=${memory}. Review developer_instructions for memory-related content to remove." >&2
+  fi
+
+  success_count=$((success_count + 1))
+done
+
+if [[ $success_count -eq 0 ]]; then
+  echo "Error: No files were converted." >&2
+  exit 1
+fi


### PR DESCRIPTION
## 変更内容

### サブエージェント定義
- **investigation-scout** (Phase.1): 広く浅くコードベースをスキャンし Scout Report を返す
- **investigation-diver** (Phase.2): Scout Report を受け取り深く証拠ベースで分析する

### agents-copy make ターゲット
- `make agents-copy`: 全ツール一括コピー
- `make claude-agents-copy`: `~/.claude/agents/` に .md コピー
- `make cursor-agents-copy`: `~/.cursor/agents/` に .md コピー
- `make codex-agents-copy`: `~/.codex/agents/` に .toml コピー + `config.toml` 登録

### Codex CLI 対応
- `agents/codex/investigation-scout.toml` / `investigation-diver.toml` を作成
- model: sonnet → `gpt-5.3-codex`、permissionMode: plan → `sandbox_mode = "read-only"`

### agent-codex-convert スキル
- Claude/Cursor 用 MD → Codex 用 TOML への自動変換スキル
- `--dry-run`, `--force`, `--reasoning-effort`, `--output-dir` オプション対応
- memory フィールド検出時は WARNING 出力（手動レビュー前提）

## 変更理由

調査用サブエージェント（Incremental Drilling パターン）を各 AI ツールへ簡単にデプロイでき、
新規エージェント追加時の MD→TOML 変換を自動化するため。

## 注意事項

- Codex の `config.toml` 登録は追記のみ（既存エントリはスキップ）
- 変換スクリプトの memory 削除は自動化していない（出現パターンが多様なため）
- `agents/` はバージョン管理用。実運用には `make agents-copy` で各ツールにデプロイが必要