### PR TITLE
Improve subagent definitions based on code review

### DIFF
--- a/agents/code-review-critic.md
+++ b/agents/code-review-critic.md
@@ -6,6 +6,7 @@ model: opus
 permissionMode: plan
 memory: project
 maxTurns: 30
+color: yellow
 ---
 
 You are a code review critic. Your role is Phase.2 of the code review pipeline: take the Scan Report from Phase.1 and conduct a rigorous, evidence-based review of the flagged issues. You provide concrete, actionable feedback and a final verdict.

--- a/agents/code-review-scanner.md
+++ b/agents/code-review-scanner.md
@@ -5,6 +5,7 @@ tools: Read, Grep, Glob, Bash
 model: sonnet
 permissionMode: default
 maxTurns: 20
+color: yellow
 ---
 
 You are a code review scanner. Your role is Phase.1 of the code review pipeline: scan the changes broadly, flag potential issues by category, and produce a structured report for the deeper critic to work from.

--- a/agents/investigation-diver.md
+++ b/agents/investigation-diver.md
@@ -5,6 +5,8 @@ tools: Read, Grep, Glob
 model: sonnet
 permissionMode: plan
 memory: project
+maxTurns: 25
+color: cyan
 ---
 
 You are an investigation diver. Your role is Phase.2 of the Incremental Drilling pattern: take the Scout Report(s) from Phase.1 and dig deep into the high-priority candidates with rigorous, evidence-based analysis.
@@ -24,7 +26,11 @@ When given one or more Scout Reports:
 
 - **Evidence over intuition.** If you cannot cite a line number, do not assert it as fact.
 - **No fixes.** You are read-only. Never suggest code changes inline; only note them in Recommended Actions.
-- **Handle multiple Scout Reports.** When receiving reports from parallel scouts (Layered Delegation), synthesize across all domains before diving — look for cross-cutting patterns.
+- **Handle multiple Scout Reports.** When receiving reports from parallel scouts (Layered Delegation):
+  1. Merge all candidate lists into a single table, preserving the source scout name
+  2. If the same file appears in multiple reports, adopt the highest priority
+  3. Look for cross-cutting patterns (e.g., same anti-pattern across domains)
+  4. Prioritize cross-cutting findings over domain-isolated ones
 - **Memory discipline.** Write concise, structured notes to memory. Avoid dumping raw file contents. Focus on patterns, architectural decisions, and recurring issues.
 
 ## Memory format

--- a/agents/investigation-scout.md
+++ b/agents/investigation-scout.md
@@ -4,6 +4,8 @@ description: "Phase.1 investigation agent for Incremental Drilling. Broadly and 
 tools: Read, Grep, Glob
 model: sonnet
 permissionMode: plan
+maxTurns: 15
+color: cyan
 ---
 
 You are an investigation scout. Your role is Phase.1 of the Incremental Drilling pattern: scan broadly and shallowly to map the territory, then hand off a structured report to a deeper investigator.
@@ -41,8 +43,8 @@ Always end your response with a Scout Report in exactly this format:
 
 | 優先度 | ファイル / モジュール | 根拠                     |
 | ------ | --------------------- | ------------------------ |
-| High   | path/to/file.ts       | (why this is suspicious) |
-| Medium | path/to/other.ts      | (brief reason)           |
+| High   | path/to/file          | (why this is suspicious) |
+| Medium | path/to/other         | (brief reason)           |
 
 ### 推奨 Phase.2 クエリ
 


### PR DESCRIPTION
## 変更内容

- investigation-scout/diver に `maxTurns` と `color: cyan` を追加
- code-review-scanner/critic に `color: yellow` を追加
- investigation-diver の複数 Scout Report 統合ルールを具体化
- investigation-scout のテンプレートサンプル値から `.ts` 拡張子を除去

## 変更理由

code-review-scanner → code-review-critic の2フェーズレビューで以下の改善点が見つかった:

- investigation 系に `maxTurns`/`color` が未設定で code-review 系と非対称だった
- 複数 Scout Report 受信時の統合手順が曖昧だった
- サンプル値が `.ts` 固定で言語非依存エージェントとして不適切だった

## 技術的な詳細

- `maxTurns`: scout=15（広く浅いスキャン）, diver=25（深い分析）
- `color`: cyan（code-review 系の yellow と視覚的に区別）
- 統合ルール: 候補マージ → 最高優先度採用 → クロスカッティング優先の3段階

## 注意事項

- code-review 系の `color: yellow` は既存 frontmatter への追記のみ
- investigation-diver の統合ルールは numbered list で具体化