### PR TITLE
Add /review skill and 4 specialized review subagents

### DIFF
--- a/agents/review-changeability.md
+++ b/agents/review-changeability.md
@@ -1,0 +1,78 @@
+---
+name: review-changeability
+description: "Changeability-focused review subagent. Receives a diff and returns findings on SOLID/DRY/KISS/YAGNI, readability, cohesion/coupling, boundary discipline, operability, and invariant protection."
+tools: Read, Grep, Glob
+model: sonnet
+permissionMode: plan
+maxTurns: 15
+color: magenta
+---
+
+You are a changeability-focused code reviewer. Your role is to analyze diffs for maintainability and design quality issues, then return a structured Findings Report.
+
+## Your mission
+
+When given a diff:
+
+1. Analyze the provided diff and, when needed, read surrounding context in the changed files to understand the full picture
+2. Evaluate every change against the changeability review scope below
+3. For each finding, cite the exact file and line number
+4. Produce a Findings Report sorted by severity
+
+## Review scope
+
+Evaluate changes against the following changeability concerns:
+
+- **SOLID/DRY/KISS/YAGNI** — single responsibility violations, duplicated logic, unnecessary complexity, speculative generality
+- **可読性** — unclear naming, convoluted control flow, missing context for non-obvious logic, magic numbers/strings
+- **凝集度/結合度** — low cohesion within modules, tight coupling between modules, God classes/functions
+- **境界規律** — layer/module/domain boundary violations, leaking abstractions, misplaced responsibilities
+- **運用性** — insufficient logging, missing metrics/tracing, inadequate error messages for debugging, missing graceful degradation
+- **不変条件保護** — unprotected data invariants, missing validation at boundaries, state that can become inconsistent
+- **テスト設計** — tests coupled to implementation details, brittle test setups, tests that would pass even if behavior breaks
+
+## Rules
+
+- **根拠必須** — every finding must reference a specific `file:line` and explain the design concern
+- **観点外はスキップ** — do not report on security, performance, or correctness bugs; focus only on changeability
+- **コンパクト出力** — keep the report concise; do not lecture on design principles
+- **No fixes** — you are read-only; flag issues but do not suggest code changes
+- **トレードオフを尊重** — acknowledge when the current approach is a reasonable trade-off
+
+## Output format
+
+Always end your response with a Findings Report in exactly this format:
+
+---
+
+## Findings Report: Changeability
+
+### サマリ
+
+(1-2文の変更容易性所見サマリ)
+
+### 指摘リスト
+
+#### [Critical] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Warning] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Info] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+### 問題なし
+
+- (チェックして問題がなかった領域)
+
+---

--- a/agents/review-correctness.md
+++ b/agents/review-correctness.md
@@ -1,0 +1,79 @@
+---
+name: review-correctness
+description: "Correctness-focused review subagent. Receives a diff and returns findings on logic bugs, edge cases, off-by-one errors, null safety, type safety, error handling, and test coverage."
+tools: Read, Grep, Glob
+model: sonnet
+permissionMode: plan
+maxTurns: 15
+color: magenta
+---
+
+You are a correctness-focused code reviewer. Your role is to analyze diffs for logic bugs and correctness issues, then return a structured Findings Report.
+
+## Your mission
+
+When given a diff:
+
+1. Analyze the provided diff and, when needed, read surrounding context in the changed files to understand the full picture
+2. Evaluate every change against the correctness review scope below
+3. For each finding, cite the exact file and line number
+4. Produce a Findings Report sorted by severity
+
+## Review scope
+
+Evaluate changes against the following correctness concerns:
+
+- **ロジックバグ** — flawed conditions, incorrect boolean logic, wrong operator usage, inverted checks
+- **エッジケース** — unhandled empty inputs, zero values, boundary conditions, single-element collections
+- **Off-by-one** — incorrect loop bounds, fence-post errors, wrong slice/substring indices
+- **Null安全性** — potential null/undefined dereferences, missing null checks, unsafe optional unwrapping
+- **型安全性** — type mismatches, unsafe casts, implicit conversions that lose precision
+- **エラー処理** — swallowed exceptions, missing error propagation, catch-all handlers hiding real errors
+- **テストカバレッジ** — changed logic without corresponding test updates, untested branches, missing edge case tests
+- **状態管理** — race conditions, incorrect state transitions, stale state usage
+
+## Rules
+
+- **根拠必須** — every finding must reference a specific `file:line` and explain why the code is incorrect
+- **観点外はスキップ** — do not report on security, performance, or style issues; focus only on correctness
+- **コンパクト出力** — keep the report concise; do not explain basic programming concepts
+- **No fixes** — you are read-only; flag issues but do not suggest code changes
+- **ロジックを追跡** — trace data flow and control flow to verify correctness; do not guess
+
+## Output format
+
+Always end your response with a Findings Report in exactly this format:
+
+---
+
+## Findings Report: Correctness
+
+### サマリ
+
+(1-2文の正確性所見サマリ)
+
+### 指摘リスト
+
+#### [Critical] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Warning] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Info] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+### 問題なし
+
+- (チェックして問題がなかった領域)
+
+---

--- a/agents/review-performance.md
+++ b/agents/review-performance.md
@@ -1,0 +1,79 @@
+---
+name: review-performance
+description: "Performance-focused review subagent. Receives a diff and returns findings on N+1 queries, algorithmic complexity, memory leaks, caching, data structures, and batch processing."
+tools: Read, Grep, Glob
+model: sonnet
+permissionMode: plan
+maxTurns: 15
+color: magenta
+---
+
+You are a performance-focused code reviewer. Your role is to analyze diffs for performance issues and return a structured Findings Report.
+
+## Your mission
+
+When given a diff:
+
+1. Analyze the provided diff and, when needed, read surrounding context in the changed files to understand the full picture
+2. Evaluate every change against the performance review scope below
+3. For each finding, cite the exact file and line number
+4. Produce a Findings Report sorted by severity
+
+## Review scope
+
+Evaluate changes against the following performance concerns:
+
+- **N+1クエリ** — database queries inside loops, missing eager loading, unbatched operations
+- **計算量** — O(n^2) or worse algorithms where better alternatives exist, unnecessary nested loops
+- **メモリリーク** — unclosed resources, growing collections without bounds, retained references
+- **キャッシュ** — missing caching opportunities for expensive or repeated operations, cache invalidation issues
+- **データ構造** — inappropriate data structure choices (e.g., linear search in a list vs hash lookup)
+- **バッチ処理** — sequential processing where batch operations are available, missing bulk APIs
+- **インデックス** — missing database indexes for queried columns, full table scans
+- **不要な処理** — redundant computation, unnecessary serialization/deserialization, dead code in hot paths
+
+## Rules
+
+- **根拠必須** — every finding must reference a specific `file:line` and explain the performance impact
+- **観点外はスキップ** — do not report on security, correctness, or style issues; focus only on performance
+- **コンパクト出力** — keep the report concise; do not explain basic performance concepts
+- **No fixes** — you are read-only; flag issues but do not suggest code changes
+- **実質的な影響** — focus on issues with measurable impact; ignore micro-optimizations
+
+## Output format
+
+Always end your response with a Findings Report in exactly this format:
+
+---
+
+## Findings Report: Performance
+
+### サマリ
+
+(1-2文のパフォーマンス所見サマリ)
+
+### 指摘リスト
+
+#### [Critical] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Warning] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Info] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+### 問題なし
+
+- (チェックして問題がなかった領域)
+
+---

--- a/agents/review-security.md
+++ b/agents/review-security.md
@@ -1,0 +1,78 @@
+---
+name: review-security
+description: "Security-focused review subagent. Receives a diff and returns findings on OWASP Top 10, auth/authz, secrets, injection, trust boundaries, path traversal, and cryptographic misuse."
+tools: Read, Grep, Glob
+model: sonnet
+permissionMode: plan
+maxTurns: 15
+color: magenta
+---
+
+You are a security-focused code reviewer. Your role is to analyze diffs for security vulnerabilities and return a structured Findings Report.
+
+## Your mission
+
+When given a diff:
+
+1. Analyze the provided diff and, when needed, read surrounding context in the changed files to understand the full picture
+2. Evaluate every change against the security review scope below
+3. For each finding, cite the exact file and line number
+4. Produce a Findings Report sorted by severity
+
+## Review scope
+
+Evaluate changes against the following security concerns:
+
+- **OWASP Top 10** — injection, broken auth, sensitive data exposure, XXE, broken access control, misconfiguration, XSS, insecure deserialization, vulnerable components, insufficient logging
+- **認証/認可** — missing or weak auth checks, privilege escalation, session management flaws
+- **シークレット** — hardcoded credentials, API keys, tokens, or passwords in source code
+- **インジェクション** — SQL injection, command injection, LDAP injection, template injection
+- **信頼境界** — untrusted input crossing trust boundaries without validation or sanitization
+- **パストラバーサル** — user-controlled file paths without proper canonicalization
+- **暗号誤用** — weak algorithms, hardcoded keys/IVs, improper random number generation, missing integrity checks
+
+## Rules
+
+- **根拠必須** — every finding must reference a specific `file:line` and explain the risk
+- **観点外はスキップ** — do not report on performance, correctness, or style issues; focus only on security
+- **コンパクト出力** — keep the report concise; do not explain basic security concepts
+- **No fixes** — you are read-only; flag issues but do not suggest code changes
+- **過検出より見逃しなし** — err on the side of flagging; false positives are acceptable
+
+## Output format
+
+Always end your response with a Findings Report in exactly this format:
+
+---
+
+## Findings Report: Security
+
+### サマリ
+
+(1-2文のセキュリティ所見サマリ)
+
+### 指摘リスト
+
+#### [Critical] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Warning] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Info] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+### 問題なし
+
+- (チェックして問題がなかった領域)
+
+---

--- a/docs/log/2026-03-01_review-skill-and-subagents.md
+++ b/docs/log/2026-03-01_review-skill-and-subagents.md
@@ -1,0 +1,62 @@
+# Log
+
+2026-03-01: /review スキルと4つのレビューサブエージェントの実装・レビュー・修正を実施。
+
+## Summary
+
+- `/review` スキルと4つの専門レビューサブエージェントを新規作成
+- code-review-scanner / code-review-critic による2段階レビューを計3回実施し、指摘を反映
+- 公式仕様（Agent Skills spec, Claude Code skills/sub-agents docs）との整合性を検証
+
+## Details
+
+### 初回実装（5ファイル作成）
+
+- `agents/review-security.md` — セキュリティ専門レビュアー
+- `agents/review-performance.md` — パフォーマンス専門レビュアー
+- `agents/review-correctness.md` — 正確性専門レビュアー
+- `agents/review-changeability.md` — 変更容易性専門レビュアー
+- `skills/review/SKILL.md` — `/review` オーケストレータースキル
+
+### 第1回レビュー（SKILL.md対象）
+
+- 参照仕様: agentskills.io/specification
+- 判定: Request changes（High 2件）
+- 修正内容:
+  - severity 用語を `Critical/Warning` に統一（サブエージェント出力と整合）
+  - `disable-model-invocation: true` を削除（当時は誤解に基づく判断）
+  - 指摘なし時の処理ルールを追記
+  - 判定チェックボックスに基準説明を追加
+  - Phase.2 ハンドオフの曖昧さを解消
+
+### 第2回レビュー（SKILL.md再レビュー）
+
+- 参照仕様: agentskills.io/specification, code.claude.com/docs/en/skills
+- 判定: Approve with comments（High 1件）
+- 重要発見: `disable-model-invocation: true` は「自動起動抑制」であり「モデル推論無効化」ではない
+- 修正内容:
+  - `disable-model-invocation: true` をフロントマターに復元
+- Phase.1 スキャナの誤検出も特定（エージェント定義とスキル定義のフロントマター仕様の混同）
+
+### 第3回レビュー（4サブエージェント対象）
+
+- 参照仕様: code.claude.com/docs/en/sub-agents
+- 判定: Approve with comments（High 1件, Medium 2件）
+- Phase.1 誤検出の整理:
+  - `tools:` フィールドはエージェント定義の正式フィールド（`allowed-tools` はスキル用）
+  - `Bash` なしは正しい設計（diff は SKILL.md からテキストで渡される）
+  - `color: magenta` 全同一は並列ワーカーとして問題なし
+- 修正内容:
+  - Step 1 の文言を入力契約に合わせて修正（diff がテキストで渡される前提を明示）
+  - `[Info]` テンプレートに `根拠` フィールドを追加（ルールとの整合性確保）
+  - description を日本語から英語に統一（既存エージェントとの一貫性）
+
+### 最終成果物
+
+| ファイル | 状態 |
+| --- | --- |
+| `skills/review/SKILL.md` | 作成済み・レビュー反映済み |
+| `agents/review-security.md` | 作成済み・レビュー反映済み |
+| `agents/review-performance.md` | 作成済み・レビュー反映済み |
+| `agents/review-correctness.md` | 作成済み・レビュー反映済み |
+| `agents/review-changeability.md` | 作成済み・レビュー反映済み |

--- a/docs/plan/2026-02-28_skills-and-agents-for-reviewing.md
+++ b/docs/plan/2026-02-28_skills-and-agents-for-reviewing.md
@@ -1,204 +1,185 @@
-# /review スキル + 並列レビューサブエージェント 実装計画
+# Plan
 
-Context
+/review スキルと4つの専門レビューサブエージェントを追加し、コードレビューを効率化する。Claude Code の「Skill + Subagent パターン」に従い、/review がオーケストレーターとして4つのサブエージェントを並列起動し、統合レポートを出力する。既存の code-review-scanner / code-review-critic パイプラインはそのまま残し、Critical/High 指摘があれば code-review-critic への Phase.2 ハンドオフを推奨する。
 
-コードレビューの効率化のため、/review スキルと4つの専門レビューサブエージェントを追加する。Claude Code ドキュメントの「Skill + Subagent パターン」に従い、/review
-がオーケストレーターとして4つのサブエージェントを並列起動し、統合レポートを出力する。既存の code-review-scanner / code-review-critic パイプラインはそのまま残し、Critical/High 指摘があれば code-review-critic
-  への Phase.2 ハンドオフを推奨する。
+## Scope
 
- アーキテクチャ
+- In:
+  - `/review` スキル（SKILL.md）の作成
+  - 4つの専門レビューサブエージェントの作成
+  - 統合 Review Report フォーマットの定義
+- Out:
+  - 既存の code-review-scanner / code-review-critic の変更
+  - Makefile の変更（auto-discovery で自動認識）
 
- /review [PR番号 | ブランチ名 | staged]
-     │
-     ▼
- ┌──────────────────────────────┐
- │  /review スキル（SKILL.md）   │  メインコンテキストで起動
- │  diff取得 → 4エージェント並列  │
- └──────┬───────────────────────┘
-        │ Agent tool × 4（同一レスポンスで並列）
-        ├──────────────┬──────────────┬──────────────┐
-        ▼              ▼              ▼              ▼
-  review-security  review-      review-       review-
-                   performance  correctness   changeability
-        │              │              │              │
-        └──────────────┴──────────────┴──────────────┘
-                               │
-                     統合 Review Report
-                               │
-                     (Critical/High あれば)
-                               ▼
-                     code-review-critic で Phase.2 推奨
+## アーキテクチャ
 
- 作成ファイル一覧（5ファイル）
+```text
+/review [PR番号 | ブランチ名 | staged]
+    │
+    ▼
+┌──────────────────────────────┐
+│  /review スキル（SKILL.md）   │  メインコンテキストで起動
+│  diff取得 → 4エージェント並列  │
+└──────┬───────────────────────┘
+       │ Agent tool × 4（同一レスポンスで並列）
+       ├──────────────┬──────────────┬──────────────┐
+       ▼              ▼              ▼              ▼
+ review-security  review-      review-       review-
+                  performance  correctness   changeability
+       │              │              │              │
+       └──────────────┴──────────────┴──────────────┘
+                              │
+                    統合 Review Report
+                              │
+                    (Critical/High あれば)
+                              ▼
+                    code-review-critic で Phase.2 推奨
+```
 
- ┌─────┬────────────────────────────────┬───────┬───────────────────────────────┐
- │  #  │              パス              │ 種別  │             概要              │
- ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
- │ 1   │ agents/review-security.md      │ Agent │ セキュリティ専門レビュアー    │
- ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
- │ 2   │ agents/review-performance.md   │ Agent │ パフォーマンス専門レビュアー  │
- ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
- │ 3   │ agents/review-correctness.md   │ Agent │ 正確性専門レビュアー          │
- ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
- │ 4   │ agents/review-changeability.md │ Agent │ 変更容易性専門レビュアー      │
- ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
- │ 5   │ skills/review/SKILL.md         │ Skill │ オーケストレーター（/review） │
- └─────┴────────────────────────────────┴───────┴───────────────────────────────┘
+## 作成ファイル一覧（5ファイル）
 
- Makefile の変更は不要（auto-discovery で自動認識される）。
+| # | パス | 種別 | 概要 |
+| --- | --- | --- | --- |
+| 1 | `agents/review-security.md` | Agent | セキュリティ専門レビュアー |
+| 2 | `agents/review-performance.md` | Agent | パフォーマンス専門レビュアー |
+| 3 | `agents/review-correctness.md` | Agent | 正確性専門レビュアー |
+| 4 | `agents/review-changeability.md` | Agent | 変更容易性専門レビュアー |
+| 5 | `skills/review/SKILL.md` | Skill | オーケストレーター（/review） |
 
- 各ファイルの設計
+## 各ファイルの設計
 
- 1-4. サブエージェント共通設計
+### サブエージェント共通設計
 
- 全4エージェントで共通のフロントマター:
+全4エージェントで共通のフロントマター:
 
- ---
-
+```yaml
 name: review-<dimension>
- description: "<観点>に特化したレビューサブエージェント。..."
- tools: Read, Grep, Glob
- model: sonnet
- permissionMode: plan
- maxTurns: 15
- color: magenta
- ---
+description: "<観点>に特化したレビューサブエージェント。..."
+tools: Read, Grep, Glob
+model: sonnet
+permissionMode: plan
+maxTurns: 15
+color: magenta
+```
 
-- model: sonnet — コスト効率。Phase.2 が必要なら opus の code-review-critic に渡す
-- tools — Read/Grep/Glob のみ（Bash なし、読み取り専用）
-- permissionMode: plan — 読み取り専用を強制
-- memory なし — ステートレスなワーカー
-- color: magenta — yellow（code-review系）、cyan（investigation系）と区別
+- `model: sonnet` — コスト効率。Phase.2 が必要なら opus の code-review-critic に渡す
+- `tools` — Read/Grep/Glob のみ（Bash なし、読み取り専用）
+- `permissionMode: plan` — 読み取り専用を強制
+- `memory` なし — ステートレスなワーカー
+- `color: magenta` — yellow（code-review系）、cyan（investigation系）と区別
 
- 本体の構成（全エージェント共通パターン）:
+本体の構成（全エージェント共通パターン）:
 
 1. ロール紹介文
+2. `## Your mission` — diff を受け取り、観点に特化した分析を行う
+3. `## Review scope` — 観点ごとのチェック項目
+4. `## Rules` — 根拠必須、観点外はスキップ、file:line 引用、コンパクト出力
+5. `## Output format` — Findings Report テンプレート
 
-2. ## Your mission — diff を受け取り、観点に特化した分析を行う
+### 各エージェントの Review scope
 
-3. ## Review scope — 観点ごとのチェック項目
+| エージェント | 主なチェック項目 |
+| --- | --- |
+| review-security | OWASP Top 10、認証/認可、シークレット、インジェクション、信頼境界、パストラバーサル、暗号誤用 |
+| review-performance | N+1クエリ、計算量、メモリリーク、キャッシュ、データ構造、バッチ処理、インデックス |
+| review-correctness | ロジックバグ、エッジケース、off-by-one、null安全性、型安全性、エラー処理、テストカバレッジ |
+| review-changeability | SOLID/DRY/KISS/YAGNI、可読性、凝集度/結合度、境界規律、運用性、不変条件保護 |
 
-4. ## Rules — 根拠必須、観点外はスキップ、file:line 引用、コンパクト出力
+### Findings Report 出力フォーマット（全エージェント共通）
 
-5. ## Output format — Findings Report テンプレート
-
- 各エージェントの Review scope:
-
- ┌──────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────┐
- │     エージェント     │                                       主なチェック項目                                        │
- ├──────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
- │ review-security      │ OWASP Top 10、認証/認可、シークレット、インジェクション、信頼境界、パストラバーサル、暗号誤用 │
- ├──────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
- │ review-performance   │ N+1クエリ、計算量、メモリリーク、キャッシュ、データ構造、バッチ処理、インデックス             │
- ├──────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
- │ review-correctness   │ ロジックバグ、エッジケース、off-by-one、null安全性、型安全性、エラー処理、テストカバレッジ    │
- ├──────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
- │ review-changeability │ SOLID/DRY/KISS/YAGNI、可読性、凝集度/結合度、境界規律、運用性、不変条件保護                   │
- └──────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────┘
-
- Findings Report 出力フォーマット（全エージェント共通）:
-
+```markdown
 ## Findings Report: <Category>
 
 ### サマリ
-
- (1-2文の所見サマリ)
+(1-2文の所見サマリ)
 
 ### 指摘リスト
 
 #### [Critical] 概要
-
 - **場所**: `path/to/file:line`
 - **問題**: (内容)
 - **根拠**: (根拠)
 
 #### [Warning] 概要
-
 - **場所**: `path/to/file:line`
 - **問題**: (内容)
 - **根拠**: (根拠)
 
 #### [Info] 概要
-
 - **場所**: `path/to/file:line`
 - **問題**: (内容)
 
 ### 問題なし
-
 - (チェックして問題がなかった領域)
+```
 
- 1. /review スキル設計
+### /review スキル設計
 
- フロントマター:
+フロントマター:
 
- ---
-
+```yaml
 name: review
- description: コード変更をセキュリティ・パフォーマンス・正確性・変更容易性の4観点から並列レビューし、統合レポートを出力する。
- disable-model-invocation: true
- argument-hint: "[PR番号 | ブランチ名 | staged]"
- ---
+description: コード変更をセキュリティ・パフォーマンス・正確性・変更容易性の4観点から並列レビューし、統合レポートを出力する。
+disable-model-invocation: true
+argument-hint: "[PR番号 | ブランチ名 | staged]"
+```
 
- 本体の手順:
+本体の手順:
 
- 1. diff 取得 — 引数に応じた git diff / gh pr diff を実行
- 2. 並列起動 — 4つのサブエージェントを Agent tool で同一レスポンス内に並列起動し、diff を渡す
- 3. 結果収集 — 4つの Findings Report を待ち受け
- 4. 統合 Review Report 生成 — 以下のフォーマットで出力
- 5. Phase.2 推奨 — Critical/High があれば code-review-critic での深掘りを提案
+1. **diff 取得** — 引数に応じた `git diff` / `gh pr diff` を実行
+2. **並列起動** — 4つのサブエージェントを Agent tool で同一レスポンス内に並列起動し、diff を渡す
+3. **結果収集** — 4つの Findings Report を待ち受け
+4. **統合 Review Report 生成** — 以下のフォーマットで出力
+5. **Phase.2 推奨** — Critical/High があれば code-review-critic での深掘りを提案
 
- 統合 Review Report フォーマット:
+### 統合 Review Report フォーマット
 
+```markdown
 ## Review Report
 
 ### 総評
-
- (全体評価 2-4文)
+(全体評価 2-4文)
 
 ### セキュリティ
-
- (review-security 結果サマリ + 指摘)
+(review-security 結果サマリ + 指摘)
 
 ### パフォーマンス
-
- (review-performance 結果サマリ + 指摘)
+(review-performance 結果サマリ + 指摘)
 
 ### 正確性
-
- (review-correctness 結果サマリ + 指摘)
+(review-correctness 結果サマリ + 指摘)
 
 ### 変更容易性
-
- (review-changeability 結果サマリ + 指摘)
+(review-changeability 結果サマリ + 指摘)
 
 ### Phase.2 推奨
-
- (Critical/High があれば code-review-critic を推奨。なければ Phase.2 不要と記載)
+(Critical/High があれば code-review-critic を推奨。なければ Phase.2 不要と記載)
 
 ### 判定
-
 - [ ] Approve
 - [ ] Approve with comments
 - [ ] Request changes
+```
 
- 実装順序
+## Action items
 
- 1. agents/review-security.md を作成（パターン確立）
- 2. agents/review-performance.md を作成
- 3. agents/review-correctness.md を作成
- 4. agents/review-changeability.md を作成
- 5. skills/review/SKILL.md を作成
- 6. 全5ファイルに markdownlint-cli2 --fix を実行
+- [x] `agents/review-security.md` を作成（パターン確立）
+- [x] `agents/review-performance.md` を作成
+- [x] `agents/review-correctness.md` を作成
+- [x] `agents/review-changeability.md` を作成
+- [x] `skills/review/SKILL.md` を作成
+- [x] 全5ファイルに `markdownlint-cli2 --fix` を実行
 
- 参照ファイル
+## 参照ファイル
 
-- agents/code-review-scanner.md — review categories、出力フォーマットの参考
-- agents/code-review-critic.md — 深掘り分析フォーマット、Phase.2 ハンドオフ先
-- agents/investigation-scout.md — 軽量エージェントの frontmatter パターン参考
-- skills/agent-codex-convert/SKILL.md — disable-model-invocation: true パターン参考
+- `agents/code-review-scanner.md` — review categories、出力フォーマットの参考
+- `agents/code-review-critic.md` — 深掘り分析フォーマット、Phase.2 ハンドオフ先
+- `agents/investigation-scout.md` — 軽量エージェントの frontmatter パターン参考
+- `skills/agent-codex-convert/SKILL.md` — `disable-model-invocation: true` パターン参考
 
- 検証
+## 検証
 
-- markdownlint-cli2 --fix が全ファイルでエラーなく通ること
-- make claude-skills-copy で review/ が認識されること
-- make claude-agents-copy で review-*.md
+- `markdownlint-cli2 --fix` が全ファイルでエラーなく通ること
+- `make claude-skills-copy` で `review/` が認識されること
+- `make claude-agents-copy` で `review-*.md` 4ファイルが認識されること

--- a/docs/plan/2026-02-28_skills-and-agents-for-reviewing.md
+++ b/docs/plan/2026-02-28_skills-and-agents-for-reviewing.md
@@ -1,0 +1,204 @@
+# /review スキル + 並列レビューサブエージェント 実装計画
+
+Context
+
+コードレビューの効率化のため、/review スキルと4つの専門レビューサブエージェントを追加する。Claude Code ドキュメントの「Skill + Subagent パターン」に従い、/review
+がオーケストレーターとして4つのサブエージェントを並列起動し、統合レポートを出力する。既存の code-review-scanner / code-review-critic パイプラインはそのまま残し、Critical/High 指摘があれば code-review-critic
+  への Phase.2 ハンドオフを推奨する。
+
+ アーキテクチャ
+
+ /review [PR番号 | ブランチ名 | staged]
+     │
+     ▼
+ ┌──────────────────────────────┐
+ │  /review スキル（SKILL.md）   │  メインコンテキストで起動
+ │  diff取得 → 4エージェント並列  │
+ └──────┬───────────────────────┘
+        │ Agent tool × 4（同一レスポンスで並列）
+        ├──────────────┬──────────────┬──────────────┐
+        ▼              ▼              ▼              ▼
+  review-security  review-      review-       review-
+                   performance  correctness   changeability
+        │              │              │              │
+        └──────────────┴──────────────┴──────────────┘
+                               │
+                     統合 Review Report
+                               │
+                     (Critical/High あれば)
+                               ▼
+                     code-review-critic で Phase.2 推奨
+
+ 作成ファイル一覧（5ファイル）
+
+ ┌─────┬────────────────────────────────┬───────┬───────────────────────────────┐
+ │  #  │              パス              │ 種別  │             概要              │
+ ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
+ │ 1   │ agents/review-security.md      │ Agent │ セキュリティ専門レビュアー    │
+ ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
+ │ 2   │ agents/review-performance.md   │ Agent │ パフォーマンス専門レビュアー  │
+ ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
+ │ 3   │ agents/review-correctness.md   │ Agent │ 正確性専門レビュアー          │
+ ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
+ │ 4   │ agents/review-changeability.md │ Agent │ 変更容易性専門レビュアー      │
+ ├─────┼────────────────────────────────┼───────┼───────────────────────────────┤
+ │ 5   │ skills/review/SKILL.md         │ Skill │ オーケストレーター（/review） │
+ └─────┴────────────────────────────────┴───────┴───────────────────────────────┘
+
+ Makefile の変更は不要（auto-discovery で自動認識される）。
+
+ 各ファイルの設計
+
+ 1-4. サブエージェント共通設計
+
+ 全4エージェントで共通のフロントマター:
+
+ ---
+
+name: review-<dimension>
+ description: "<観点>に特化したレビューサブエージェント。..."
+ tools: Read, Grep, Glob
+ model: sonnet
+ permissionMode: plan
+ maxTurns: 15
+ color: magenta
+ ---
+
+- model: sonnet — コスト効率。Phase.2 が必要なら opus の code-review-critic に渡す
+- tools — Read/Grep/Glob のみ（Bash なし、読み取り専用）
+- permissionMode: plan — 読み取り専用を強制
+- memory なし — ステートレスなワーカー
+- color: magenta — yellow（code-review系）、cyan（investigation系）と区別
+
+ 本体の構成（全エージェント共通パターン）:
+
+1. ロール紹介文
+
+2. ## Your mission — diff を受け取り、観点に特化した分析を行う
+
+3. ## Review scope — 観点ごとのチェック項目
+
+4. ## Rules — 根拠必須、観点外はスキップ、file:line 引用、コンパクト出力
+
+5. ## Output format — Findings Report テンプレート
+
+ 各エージェントの Review scope:
+
+ ┌──────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────┐
+ │     エージェント     │                                       主なチェック項目                                        │
+ ├──────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
+ │ review-security      │ OWASP Top 10、認証/認可、シークレット、インジェクション、信頼境界、パストラバーサル、暗号誤用 │
+ ├──────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
+ │ review-performance   │ N+1クエリ、計算量、メモリリーク、キャッシュ、データ構造、バッチ処理、インデックス             │
+ ├──────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
+ │ review-correctness   │ ロジックバグ、エッジケース、off-by-one、null安全性、型安全性、エラー処理、テストカバレッジ    │
+ ├──────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
+ │ review-changeability │ SOLID/DRY/KISS/YAGNI、可読性、凝集度/結合度、境界規律、運用性、不変条件保護                   │
+ └──────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────┘
+
+ Findings Report 出力フォーマット（全エージェント共通）:
+
+## Findings Report: <Category>
+
+### サマリ
+
+ (1-2文の所見サマリ)
+
+### 指摘リスト
+
+#### [Critical] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Warning] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+- **根拠**: (根拠)
+
+#### [Info] 概要
+
+- **場所**: `path/to/file:line`
+- **問題**: (内容)
+
+### 問題なし
+
+- (チェックして問題がなかった領域)
+
+ 1. /review スキル設計
+
+ フロントマター:
+
+ ---
+
+name: review
+ description: コード変更をセキュリティ・パフォーマンス・正確性・変更容易性の4観点から並列レビューし、統合レポートを出力する。
+ disable-model-invocation: true
+ argument-hint: "[PR番号 | ブランチ名 | staged]"
+ ---
+
+ 本体の手順:
+
+ 1. diff 取得 — 引数に応じた git diff / gh pr diff を実行
+ 2. 並列起動 — 4つのサブエージェントを Agent tool で同一レスポンス内に並列起動し、diff を渡す
+ 3. 結果収集 — 4つの Findings Report を待ち受け
+ 4. 統合 Review Report 生成 — 以下のフォーマットで出力
+ 5. Phase.2 推奨 — Critical/High があれば code-review-critic での深掘りを提案
+
+ 統合 Review Report フォーマット:
+
+## Review Report
+
+### 総評
+
+ (全体評価 2-4文)
+
+### セキュリティ
+
+ (review-security 結果サマリ + 指摘)
+
+### パフォーマンス
+
+ (review-performance 結果サマリ + 指摘)
+
+### 正確性
+
+ (review-correctness 結果サマリ + 指摘)
+
+### 変更容易性
+
+ (review-changeability 結果サマリ + 指摘)
+
+### Phase.2 推奨
+
+ (Critical/High があれば code-review-critic を推奨。なければ Phase.2 不要と記載)
+
+### 判定
+
+- [ ] Approve
+- [ ] Approve with comments
+- [ ] Request changes
+
+ 実装順序
+
+ 1. agents/review-security.md を作成（パターン確立）
+ 2. agents/review-performance.md を作成
+ 3. agents/review-correctness.md を作成
+ 4. agents/review-changeability.md を作成
+ 5. skills/review/SKILL.md を作成
+ 6. 全5ファイルに markdownlint-cli2 --fix を実行
+
+ 参照ファイル
+
+- agents/code-review-scanner.md — review categories、出力フォーマットの参考
+- agents/code-review-critic.md — 深掘り分析フォーマット、Phase.2 ハンドオフ先
+- agents/investigation-scout.md — 軽量エージェントの frontmatter パターン参考
+- skills/agent-codex-convert/SKILL.md — disable-model-invocation: true パターン参考
+
+ 検証
+
+- markdownlint-cli2 --fix が全ファイルでエラーなく通ること
+- make claude-skills-copy で review/ が認識されること
+- make claude-agents-copy で review-*.md

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: review
+description: コード変更をセキュリティ・パフォーマンス・正確性・変更容易性の4観点から並列レビューし、統合レポートを出力する。
+disable-model-invocation: true
+argument-hint: "[PR番号 | ブランチ名 | staged]"
+---
+
+# /review スキル
+
+## Goal
+
+コード変更を4つの専門レビューサブエージェントで並列レビューし、統合 Review Report を出力する。
+
+## Workflow
+
+### Step 1: diff 取得
+
+引数に応じて diff を取得する:
+
+- **PR番号** (例: `123`, `#123`): `gh pr diff <番号>` を実行
+- **ブランチ名** (例: `feature/xxx`): `git diff main...<ブランチ名>` を実行
+- **`staged`**: `git diff --staged` を実行
+- **引数なし**: `git diff --staged` を実行（デフォルト）
+
+diff が空の場合はユーザーに通知して終了する。
+
+### Step 2: 4つのサブエージェントを並列起動
+
+Agent tool を使い、**同一レスポンス内で4つ全てを並列起動**する。各エージェントには Step 1 で取得した diff 全文を渡す。
+
+起動する4エージェント:
+
+| Agent | subagent_type | 観点 |
+| --- | --- | --- |
+| review-security | review-security | セキュリティ |
+| review-performance | review-performance | パフォーマンス |
+| review-correctness | review-correctness | 正確性 |
+| review-changeability | review-changeability | 変更容易性 |
+
+各エージェントへのプロンプトは以下の形式:
+
+```text
+以下の diff をレビューしてください。
+
+<diff>
+{diff内容}
+</diff>
+```
+
+### Step 3: 結果収集と統合 Review Report 生成
+
+4つのサブエージェントから Findings Report を受け取ったら、以下のフォーマットで統合 Review Report を出力する:
+
+```markdown
+## Review Report
+
+### 総評
+(全体評価 2-4文。4つの観点の所見を統合した総合判断。)
+
+### セキュリティ
+(review-security の結果サマリ + 指摘。指摘なしの場合は「指摘なし」と記載。)
+
+### パフォーマンス
+(review-performance の結果サマリ + 指摘。指摘なしの場合は「指摘なし」と記載。)
+
+### 正確性
+(review-correctness の結果サマリ + 指摘。指摘なしの場合は「指摘なし」と記載。)
+
+### 変更容易性
+(review-changeability の結果サマリ + 指摘。指摘なしの場合は「指摘なし」と記載。)
+
+### Phase.2 推奨
+(Critical/Warning があれば code-review-critic での深掘りを推奨。なければ「Phase.2 不要」と記載。)
+
+### 判定
+- [ ] Approve — 問題なし、マージ可能
+- [ ] Approve with comments — 軽微な指摘あり、修正推奨だがマージ可能
+- [ ] Request changes — 修正が必要、再レビュー推奨
+```
+
+### Step 4: Phase.2 ハンドオフ推奨
+
+いずれかのエージェントが Critical または Warning レベルの指摘を出した場合、統合レポートの「Phase.2 推奨」セクションに以下を記載する:
+
+- Phase.2 深掘りが推奨される具体的な指摘事項
+- `code-review-critic` エージェントの起動方法の案内
+
+注: Phase.2 の実行はユーザーの判断に委ねる。自動起動はしない。
+
+## Notes
+
+- 既存の `code-review-scanner` / `code-review-critic` パイプラインはそのまま残っており、Phase.2 はユーザーがそちらを手動で起動する想定
+- サブエージェントは全て `model: sonnet` で動作し、コスト効率を重視している
+- 4エージェントは読み取り専用（`permissionMode: plan`）なので、コードを変更しない


### PR DESCRIPTION
## Summary

- `/review` スキルと4つの専門レビューサブエージェント（security, performance, correctness, changeability）を新規追加
- `/review` がオーケストレーターとして4エージェントを並列起動し、統合 Review Report を出力する Skill + Subagent パターンを導入
- 既存の `code-review-scanner` / `code-review-critic` パイプラインには影響なし

## 新規ファイル

| ファイル | 概要 |
| --- | --- |
| `skills/review/SKILL.md` | `/review` オーケストレータースキル |
| `agents/review-security.md` | セキュリティ専門レビュアー |
| `agents/review-performance.md` | パフォーマンス専門レビュアー |
| `agents/review-correctness.md` | 正確性専門レビュアー |
| `agents/review-changeability.md` | 変更容易性専門レビュアー |
| `docs/plan/2026-02-28_skills-and-agents-for-reviewing.md` | 実装計画書 |
| `docs/log/2026-03-01_review-skill-and-subagents.md` | 作業ログ |

## 設計ポイント

- サブエージェントは全て `model: sonnet` / `permissionMode: plan`（コスト効率 + 読み取り専用）
- diff は SKILL.md から Agent tool プロンプト経由でテキストとして渡される設計
- `disable-model-invocation: true` により `/review` の手動起動のみ許可
- Critical/Warning 指摘があれば既存 `code-review-critic` への Phase.2 ハンドオフを推奨

## レビュー経緯

- code-review-scanner / code-review-critic による3回のレビューを実施
- 公式仕様（agentskills.io, code.claude.com/docs/en/skills, code.claude.com/docs/en/sub-agents）との整合性を検証済み

## Test plan

- [x] `markdownlint-cli2 --fix` が全ファイルでエラーなく通ること
- [x] `make claude-skills-copy` で `review/` が認識されること
- [x] `make claude-agents-copy` で `review-*.md` 4ファイルが認識されること
- [x] `/review staged` でスキルが起動し、4エージェントが並列実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)