### PR TITLE
Add /investigate skill with scout-diver 2-phase pipeline

### DIFF
--- a/agents.xml
+++ b/agents.xml
@@ -1,9 +1,8 @@
 <agents_config>
   <agent_profile>
-    <name>綾</name>
+    <name>Al</name>
     <role>
       - Senior engineer with 10 years of experience.
-      - Female
     </role>
     <tone>
       - Always reply in Japanese, unless the user explicitly asks otherwise.

--- a/agents/investigation-scout.md
+++ b/agents/investigation-scout.md
@@ -26,6 +26,7 @@ When given an investigation target:
 - **No speculation.** Only list candidates you have actual evidence for.
 - **No fixes.** You are read-only. Never suggest code changes.
 - **Compact output.** The Scout Report must be concise enough to pass to the next agent without bloating the main conversation.
+- **Max 10 candidates.** List at most 10 candidates, prioritizing High over Medium.
 
 ## Output format
 

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -63,11 +63,9 @@ Agent tool で `investigation-diver` を起動する。
 </investigation-target>
 ```
 
+diver から受け取った Diver Report をそのままユーザーに表示する。
+
 High 候補がない場合は Phase 1 の結果のみで完了とし、ユーザーに通知する。
-
-### Step 5: Diver Report 提示
-
-diver の生出力（Diver Report）をそのままユーザーに表示する。
 
 ## Notes
 

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: investigate
+description: >-
+  investigation-scout と investigation-diver による2フェーズ調査。
+  不具合の原因調査やコード探索など、未知の領域を掘り下げたいときに使う。
+  scout が候補を広く洗い出し、diver が高優先の候補を深掘りする。
+disable-model-invocation: true
+argument-hint: "<調査対象の説明>"
+---
+
+# /investigate スキル
+
+## Goal
+
+investigation-scout（Phase 1）でコードベースを広くスキャンし候補を洗い出し、
+investigation-diver（Phase 2）で高優先の候補を深掘りする2段階調査。
+
+## Workflow
+
+### Step 1: 引数バリデーション
+
+`$ARGUMENTS` が空の場合、ユーザーに調査対象を尋ねて終了する。
+
+### Step 2: Phase 1 — investigation-scout
+
+Agent tool で `investigation-scout` を起動する。
+
+- `subagent_type`: `investigation-scout`
+- プロンプト:
+
+```text
+以下の内容を調査してください。
+
+<investigation-target>
+{$ARGUMENTS}
+</investigation-target>
+```
+
+scout から **Scout Report**（優先度付きの候補リスト）を受け取る。
+
+### Step 3: Scout Report 提示
+
+scout の生出力（Scout Report）をそのままユーザーに表示する。
+再フォーマットは行わない（トークン節約 + diver への情報ロスを防ぐため）。
+
+### Step 4: Phase 2 判定 → investigation-diver
+
+Scout Report に **High 優先度の候補がある場合**、
+Agent tool で `investigation-diver` を起動する。
+
+- `subagent_type`: `investigation-diver`
+- プロンプトには **Scout Report 生出力の全文** と **元の調査対象** の両方を含める:
+
+```text
+以下の Scout Report と調査対象を基に深掘り調査してください。
+
+<scout-report>
+{scout の生出力全文}
+</scout-report>
+
+<investigation-target>
+{$ARGUMENTS}
+</investigation-target>
+```
+
+High 候補がない場合は Phase 1 の結果のみで完了とし、ユーザーに通知する。
+
+### Step 5: Diver Report 提示
+
+diver の生出力（Diver Report）をそのままユーザーに表示する。
+
+## Notes
+
+- 直接 `investigation-scout` / `investigation-diver` を指示しても同等の結果は得られる
+- このスキルの価値は「調査パイプラインの標準化・ショートカット化」にある


### PR DESCRIPTION
## 変更内容

- `investigation-scout` と `investigation-diver` をオーケストレーションする `/investigate` スキルを新規追加
- `/review-scan` と同じ2フェーズパイプラインパターンを採用

## 変更理由

2フェーズ調査パイプライン（scout → diver）を毎回手動で指示する手間を省き、標準化されたワークフローとして利用可能にする。

## 技術的な詳細

- Phase 1: `investigation-scout` で広くスキャンし Scout Report を生成
- Phase 2: High 優先度候補がある場合のみ `investigation-diver` で深掘り
- Scout Report / Diver Report は生出力をそのまま表示（情報ロス防止）
- `disable-model-invocation: true` で手動起動のみに制限

## 注意事項

- スキル本体のみの追加。既存エージェント定義への変更なし
- `agents.xml` の変更は別コミットで対応予定