### PR TITLE
Add settings-copy make targets for deploying config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ AGENTS_MD_SRC := $(PWD)/agents
 CLAUDE_AGENTS_DEST := $(HOME)/.claude/agents
 CURSOR_AGENTS_DEST := $(HOME)/.cursor/agents
 
+SETTINGS_SRC := $(PWD)/settings
+CLAUDE_SETTINGS_DEST := $(HOME)/.claude
+CURSOR_SETTINGS_DEST := $(HOME)/.cursor
+
 .PHONY: codex-link
 codex-link:
 	@ln -sf "$(AGENTS_SRC)" "$(AGENTS_DEST)"
@@ -173,3 +177,63 @@ claude-agents-copy:
 .PHONY: cursor-agents-copy
 cursor-agents-copy:
 	$(call copy_agents_md,$(CURSOR_AGENTS_DEST))
+
+define copy_settings
+	@set -eu; \
+	src="$(SETTINGS_SRC)/$(1)"; \
+	dest="$(2)"; \
+	if [ ! -d "$$src" ]; then \
+		echo "Source settings directory not found: $$src"; \
+		exit 1; \
+	fi; \
+	tmp=$$(mktemp); \
+	trap 'rm -f "$$tmp"' EXIT; \
+	find "$$src" -type f -print0 > "$$tmp"; \
+	if [ ! -s "$$tmp" ]; then \
+		echo "No settings files found in $$src"; \
+		exit 0; \
+	fi; \
+	dup_found=0; \
+	dup_list=""; \
+	while IFS= read -r -d '' f; do \
+		rel=$${f#$$src/}; \
+		if [ -e "$$dest/$$rel" ]; then \
+			dup_found=1; \
+			dup_list="$$dup_list$$rel\n"; \
+		fi; \
+	done < "$$tmp"; \
+	overwrite=0; \
+	if [ "$$dup_found" -eq 1 ]; then \
+		echo "The following settings already exist in $$dest:"; \
+		printf "%b" "$$dup_list"; \
+		printf "Overwrite existing settings? [y/N] "; \
+		read -r ans; \
+		case "$$ans" in \
+			y|Y) overwrite=1 ;; \
+			*) overwrite=0 ;; \
+		esac; \
+	fi; \
+	while IFS= read -r -d '' f; do \
+		rel=$${f#$$src/}; \
+		dest_file="$$dest/$$rel"; \
+		if [ -e "$$dest_file" ] && [ "$$overwrite" -ne 1 ]; then \
+			echo "Skip $$rel (already exists)"; \
+			continue; \
+		fi; \
+		mkdir -p "$$(dirname "$$dest_file")"; \
+		cp -p "$$f" "$$dest_file"; \
+		echo "Installed $$rel"; \
+	done < "$$tmp"; \
+	echo "Done."
+endef
+
+.PHONY: settings-copy
+settings-copy: claude-settings-copy cursor-settings-copy
+
+.PHONY: claude-settings-copy
+claude-settings-copy:
+	$(call copy_settings,claude,$(CLAUDE_SETTINGS_DEST))
+
+.PHONY: cursor-settings-copy
+cursor-settings-copy:
+	$(call copy_settings,cursor,$(CURSOR_SETTINGS_DEST))

--- a/agents.xml
+++ b/agents.xml
@@ -10,7 +10,4 @@
       - Do NOT use formal speech.
     </tone>
   </agent_profile>
-  <workflow_rules>
-    - When creating a Markdown file, run `markdownlint-cli2 --fix {target_file}` on that file.
-  </workflow_rules>
 </agents_config>

--- a/settings/claude/hooks/goimports.sh
+++ b/settings/claude/hooks/goimports.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# CLAUDE_TOOL_OUTPUT から filePath を取得
+FILE_PATH=$(echo "$CLAUDE_TOOL_OUTPUT" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('filePath', ''))
+" 2>/dev/null)
+
+# .goファイルじゃなければ何もしない
+if [[ "$FILE_PATH" != *.go ]]; then
+  exit 0
+fi
+
+# goimportsを実行
+goimports -w "$FILE_PATH"

--- a/settings/claude/hooks/markdown-format.sh
+++ b/settings/claude/hooks/markdown-format.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+FILE_PATH=$(echo "$CLAUDE_TOOL_OUTPUT" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('filePath', ''))
+" 2>/dev/null)
+
+# .mdファイルじゃなければ何もしない
+if [[ "$FILE_PATH" != *.md ]]; then
+  exit 0
+fi
+
+# 順番に実行
+markdownlint-cli2 --fix "$FILE_PATH"
+prettier --write "$FILE_PATH"

--- a/settings/claude/settings.json
+++ b/settings/claude/settings.json
@@ -1,0 +1,59 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(go test:*)",
+      "Bash(go tool:*)",
+      "Bash(go build:*)",
+      "Bash(golangci-lint run:*)",
+      "Bash(go mod:*)",
+      "Bash(markdownlint-cli2 *)",
+      "Bash(npm run lint)",
+      "Bash(npm run test *)",
+      "Bash(prettier:*)",
+      "Bash(python3:*)",
+      "Bash(shellcheck:*)",
+      "Bash(shfmt:*)",
+      "Bash(which go:*)",
+      "Read(~/.zshrc)",
+      "Read(~/.codex/**)",
+      "Read(~/.cursor/**)",
+      "Read(~/.claude/**)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:hub.docker.com)",
+      "WebSearch"
+    ],
+    "deny": [
+      "Bash(curl:*)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)"
+    ]
+  },
+  "model": "opus",
+  "enabledPlugins": {
+    "swift-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true
+  },
+  "effortLevel": "high",
+  "autoUpdatesChannel": "latest",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/goimports.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/markdown-format.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/settings/claude/settings.json
+++ b/settings/claude/settings.json
@@ -8,6 +8,7 @@
       "Bash(go build:*)",
       "Bash(golangci-lint run:*)",
       "Bash(go mod:*)",
+      "Bash(ls:*)",
       "Bash(markdownlint-cli2 *)",
       "Bash(npm run lint)",
       "Bash(npm run test *)",

--- a/settings/cursor/hooks.json
+++ b/settings/cursor/hooks.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/goimports.sh"
+      },
+      {
+        "command": ".cursor/hooks/markdown-format.sh"
+      }
+    ]
+  }
+}

--- a/settings/cursor/hooks/goimports.sh
+++ b/settings/cursor/hooks/goimports.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+FILE_PATH=$(python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('file_path', ''))
+")
+
+if [[ "$FILE_PATH" != *.go ]]; then
+  exit 0
+fi
+
+goimports -w "$FILE_PATH"

--- a/settings/cursor/hooks/markdown-format.sh
+++ b/settings/cursor/hooks/markdown-format.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+FILE_PATH=$(python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('file_path', ''))
+")
+
+if [[ "$FILE_PATH" != *.md ]]; then
+  exit 0
+fi
+
+markdownlint-cli2 --fix "$FILE_PATH"
+prettier --write "$FILE_PATH"


### PR DESCRIPTION
## 実装経緯の説明
`settings/claude/` と `settings/cursor/` 配下の設定ファイル（settings.json, hooks/）を、それぞれ `~/.claude/` と `~/.cursor/` にディレクトリ構造を維持したままデプロイする make コマンドを追加。

## 補足
### 主な変更内容
- `settings/` ディレクトリに claude / cursor の設定ファイルを追加（settings.json, hooks/）
- `Makefile` に `copy_settings` define と 3つのターゲットを追加
  - `make settings-copy` — claude と cursor の両方をデプロイ
  - `make claude-settings-copy` — `settings/claude/` → `~/.claude/`
  - `make cursor-settings-copy` — `settings/cursor/` → `~/.cursor/`
- `agents.xml` から `workflow_rules` セクションを削除

### 技術的な詳細
- 既存の `copy_skills` / `copy_agents_md` パターンに合わせた実装
- `find` でソース内の全ファイルを列挙し、相対パスを保持してコピー
- 既存ファイルがある場合は一覧表示＋上書き確認（`Overwrite? [y/N]`）
- `cp -p` で実行権限を保持（hookスクリプト対応）

### 確認事項
- `make claude-settings-copy` で `~/.claude/settings.json` と `~/.claude/hooks/` が正しくコピーされること
- `make cursor-settings-copy` で `~/.cursor/hooks.json` と `~/.cursor/hooks/` が正しくコピーされること
- 既存ファイルがある場合に上書き確認プロンプトが表示されること
- hookスクリプトの実行権限が保持されること