### PR TITLE
Add shell script lint job to CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install shfmt
-        run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
+        run: |
+          go install mvdan.cc/sh/v3/cmd/shfmt@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run shfmt
         run: shfmt -d .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,3 +50,19 @@ jobs:
 
       - name: Run prettier
         run: npx prettier --check .
+
+  shell-lint:
+    name: shell-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install shfmt
+        run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
+
+      - name: Run shfmt
+        run: shfmt -d .
+
+      - name: Run shellcheck
+        run: shellcheck ./**/*.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,4 +67,6 @@ jobs:
         run: shfmt -d .
 
       - name: Run shellcheck
-        run: shellcheck ./**/*.sh
+        run: |
+          shopt -s globstar
+          shellcheck ./**/*.sh

--- a/settings/claude/hooks/goimports.sh
+++ b/settings/claude/hooks/goimports.sh
@@ -8,7 +8,7 @@ print(data.get('filePath', ''))
 
 # .goファイルじゃなければ何もしない
 if [[ "$FILE_PATH" != *.go ]]; then
-  exit 0
+	exit 0
 fi
 
 # goimportsを実行

--- a/settings/claude/hooks/markdown-format.sh
+++ b/settings/claude/hooks/markdown-format.sh
@@ -7,7 +7,7 @@ print(data.get('filePath', ''))
 
 # .mdファイルじゃなければ何もしない
 if [[ "$FILE_PATH" != *.md ]]; then
-  exit 0
+	exit 0
 fi
 
 # 順番に実行

--- a/settings/claude/hooks/shfmt.sh
+++ b/settings/claude/hooks/shfmt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+FILE_PATH=$(echo "$CLAUDE_TOOL_OUTPUT" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('filePath', ''))
+" 2>/dev/null)
+
+if [[ "$FILE_PATH" != *.sh ]]; then
+  exit 0
+fi
+
+shfmt -w "$FILE_PATH"

--- a/settings/claude/hooks/shfmt.sh
+++ b/settings/claude/hooks/shfmt.sh
@@ -6,7 +6,7 @@ print(data.get('filePath', ''))
 " 2>/dev/null)
 
 if [[ "$FILE_PATH" != *.sh ]]; then
-  exit 0
+	exit 0
 fi
 
 shfmt -w "$FILE_PATH"

--- a/settings/claude/settings.json
+++ b/settings/claude/settings.json
@@ -45,14 +45,9 @@
       {
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/goimports.sh"
-          },
-          {
-            "type": "command",
-            "command": ".claude/hooks/markdown-format.sh"
-          }
+          { "type": "command", "command": ".claude/hooks/goimports.sh" },
+          { "type": "command", "command": ".claude/hooks/markdown-format.sh" },
+          { "type": "command", "command": ".claude/hooks/shfmt.sh" }
         ]
       }
     ]

--- a/settings/cursor/hooks.json
+++ b/settings/cursor/hooks.json
@@ -7,6 +7,9 @@
       },
       {
         "command": ".cursor/hooks/markdown-format.sh"
+      },
+      {
+        "command": ".cursor/hooks/shfmt.sh"
       }
     ]
   }

--- a/settings/cursor/hooks/goimports.sh
+++ b/settings/cursor/hooks/goimports.sh
@@ -6,7 +6,7 @@ print(data.get('file_path', ''))
 ")
 
 if [[ "$FILE_PATH" != *.go ]]; then
-  exit 0
+	exit 0
 fi
 
 goimports -w "$FILE_PATH"

--- a/settings/cursor/hooks/markdown-format.sh
+++ b/settings/cursor/hooks/markdown-format.sh
@@ -6,7 +6,7 @@ print(data.get('file_path', ''))
 ")
 
 if [[ "$FILE_PATH" != *.md ]]; then
-  exit 0
+	exit 0
 fi
 
 markdownlint-cli2 --fix "$FILE_PATH"

--- a/settings/cursor/hooks/shfmt.sh
+++ b/settings/cursor/hooks/shfmt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+FILE_PATH=$(python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('file_path', ''))
+")
+
+if [[ "$FILE_PATH" != *.sh ]]; then
+  exit 0
+fi
+
+shfmt -w "$FILE_PATH"

--- a/settings/cursor/hooks/shfmt.sh
+++ b/settings/cursor/hooks/shfmt.sh
@@ -6,7 +6,7 @@ print(data.get('file_path', ''))
 ")
 
 if [[ "$FILE_PATH" != *.sh ]]; then
-  exit 0
+	exit 0
 fi
 
 shfmt -w "$FILE_PATH"

--- a/skills/agent-codex-convert/scripts/convert_agent_to_codex.sh
+++ b/skills/agent-codex-convert/scripts/convert_agent_to_codex.sh
@@ -149,6 +149,7 @@ for input_file in "${files[@]}"; do
 		name) name="$value" ;;
 		description) description="$value" ;;
 		tools) tools="$value" ;;
+		# shellcheck disable=SC2034
 		model) model="$value" ;;
 		permissionMode) permission_mode="$value" ;;
 		memory) memory="$value" ;;
@@ -255,6 +256,7 @@ for input_file in "${files[@]}"; do
 
 	if [[ -e "$target_file" && $force_overwrite -ne 1 ]]; then
 		if prompt_from_tty answer "File exists: ${target_file}. Overwrite? [y/N]: "; then
+			# shellcheck disable=SC2154
 			case "$answer" in
 			y | Y | yes | YES) ;;
 			*)

--- a/skills/agent-codex-convert/scripts/convert_agent_to_codex.sh
+++ b/skills/agent-codex-convert/scripts/convert_agent_to_codex.sh
@@ -145,11 +145,11 @@ for input_file in "${files[@]}"; do
 		value="${value#\"}"
 		value="${value%\"}"
 
+		# shellcheck disable=SC2034
 		case "$key" in
 		name) name="$value" ;;
 		description) description="$value" ;;
 		tools) tools="$value" ;;
-		# shellcheck disable=SC2034
 		model) model="$value" ;;
 		permissionMode) permission_mode="$value" ;;
 		memory) memory="$value" ;;

--- a/skills/agent-codex-convert/scripts/convert_agent_to_codex.sh
+++ b/skills/agent-codex-convert/scripts/convert_agent_to_codex.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'EOF'
+	cat <<'EOF'
 Usage:
   convert_agent_to_codex.sh [OPTIONS] FILE [FILE ...]
 
@@ -18,20 +18,20 @@ EOF
 }
 
 prompt_from_tty() {
-  local __var_name="$1"
-  local __prompt="$2"
-  local __value=""
+	local __var_name="$1"
+	local __prompt="$2"
+	local __value=""
 
-  if [[ ! -t 0 && ! -t 1 ]]; then
-    return 1
-  fi
+	if [[ ! -t 0 && ! -t 1 ]]; then
+		return 1
+	fi
 
-  if read -r -p "$__prompt" __value < /dev/tty; then
-    printf -v "$__var_name" "%s" "$__value"
-    return 0
-  fi
+	if read -r -p "$__prompt" __value </dev/tty; then
+		printf -v "$__var_name" "%s" "$__value"
+		return 0
+	fi
 
-  return 1
+	return 1
 }
 
 # --- Argument parsing ---
@@ -42,51 +42,51 @@ dry_run=0
 files=()
 
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --reasoning-effort)
-      reasoning_effort="${2:-}"
-      shift 2
-      ;;
-    --output-dir)
-      output_dir="${2:-}"
-      shift 2
-      ;;
-    --force)
-      force_overwrite=1
-      shift
-      ;;
-    --dry-run)
-      dry_run=1
-      shift
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    -*)
-      echo "Unknown option: $1" >&2
-      usage >&2
-      exit 1
-      ;;
-    *)
-      files+=("$1")
-      shift
-      ;;
-  esac
+	case "$1" in
+	--reasoning-effort)
+		reasoning_effort="${2:-}"
+		shift 2
+		;;
+	--output-dir)
+		output_dir="${2:-}"
+		shift 2
+		;;
+	--force)
+		force_overwrite=1
+		shift
+		;;
+	--dry-run)
+		dry_run=1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-*)
+		echo "Unknown option: $1" >&2
+		usage >&2
+		exit 1
+		;;
+	*)
+		files+=("$1")
+		shift
+		;;
+	esac
 done
 
 if [[ ${#files[@]} -eq 0 ]]; then
-  echo "Error: at least one .md file is required." >&2
-  usage >&2
-  exit 1
+	echo "Error: at least one .md file is required." >&2
+	usage >&2
+	exit 1
 fi
 
 case "$reasoning_effort" in
-  low|medium|high) ;;
-  *)
-    echo "Error: --reasoning-effort must be low, medium, or high." >&2
-    exit 1
-    ;;
+low | medium | high) ;;
+*)
+	echo "Error: --reasoning-effort must be low, medium, or high." >&2
+	exit 1
+	;;
 esac
 
 # --- Main loop ---
@@ -94,192 +94,192 @@ success_count=0
 
 for input_file in "${files[@]}"; do
 
-  # Validate input
-  if [[ ! -f "$input_file" ]]; then
-    echo "Error: File not found: $input_file" >&2
-    continue
-  fi
-  if [[ "$input_file" != *.md ]]; then
-    echo "Error: Not a .md file: $input_file" >&2
-    continue
-  fi
+	# Validate input
+	if [[ ! -f "$input_file" ]]; then
+		echo "Error: File not found: $input_file" >&2
+		continue
+	fi
+	if [[ "$input_file" != *.md ]]; then
+		echo "Error: Not a .md file: $input_file" >&2
+		continue
+	fi
 
-  # Find frontmatter delimiters
-  first_delim=0
-  second_delim=0
-  line_num=0
-  while IFS= read -r line; do
-    line_num=$((line_num + 1))
-    if [[ "$line" == "---" ]]; then
-      if [[ $first_delim -eq 0 ]]; then
-        first_delim=$line_num
-      elif [[ $second_delim -eq 0 ]]; then
-        second_delim=$line_num
-        break
-      fi
-    fi
-  done < "$input_file"
+	# Find frontmatter delimiters
+	first_delim=0
+	second_delim=0
+	line_num=0
+	while IFS= read -r line; do
+		line_num=$((line_num + 1))
+		if [[ "$line" == "---" ]]; then
+			if [[ $first_delim -eq 0 ]]; then
+				first_delim=$line_num
+			elif [[ $second_delim -eq 0 ]]; then
+				second_delim=$line_num
+				break
+			fi
+		fi
+	done <"$input_file"
 
-  if [[ $first_delim -ne 1 || $second_delim -eq 0 ]]; then
-    echo "Error: Invalid frontmatter in $input_file" >&2
-    continue
-  fi
+	if [[ $first_delim -ne 1 || $second_delim -eq 0 ]]; then
+		echo "Error: Invalid frontmatter in $input_file" >&2
+		continue
+	fi
 
-  # Parse frontmatter
-  name=""
-  description=""
-  tools=""
-  model=""
-  permission_mode=""
-  memory=""
-  max_turns=""
-  background=""
+	# Parse frontmatter
+	name=""
+	description=""
+	tools=""
+	model=""
+	permission_mode=""
+	memory=""
+	max_turns=""
+	background=""
 
-  frontmatter_text=$(sed -n "2,$((second_delim - 1))p" "$input_file")
-  while IFS= read -r fm_line; do
-    [[ -z "$fm_line" || "$fm_line" == \#* ]] && continue
+	frontmatter_text=$(sed -n "2,$((second_delim - 1))p" "$input_file")
+	while IFS= read -r fm_line; do
+		[[ -z "$fm_line" || "$fm_line" == \#* ]] && continue
 
-    key="${fm_line%%:*}"
-    value="${fm_line#*: }"
-    # Strip surrounding quotes
-    value="${value#\"}"
-    value="${value%\"}"
+		key="${fm_line%%:*}"
+		value="${fm_line#*: }"
+		# Strip surrounding quotes
+		value="${value#\"}"
+		value="${value%\"}"
 
-    case "$key" in
-      name)           name="$value" ;;
-      description)    description="$value" ;;
-      tools)          tools="$value" ;;
-      model)          model="$value" ;;
-      permissionMode) permission_mode="$value" ;;
-      memory)         memory="$value" ;;
-      maxTurns)       max_turns="$value" ;;
-      background)     background="$value" ;;
-      *)              echo "Warning: Unknown frontmatter key '$key' in $input_file" >&2 ;;
-    esac
-  done <<< "$frontmatter_text"
+		case "$key" in
+		name) name="$value" ;;
+		description) description="$value" ;;
+		tools) tools="$value" ;;
+		model) model="$value" ;;
+		permissionMode) permission_mode="$value" ;;
+		memory) memory="$value" ;;
+		maxTurns) max_turns="$value" ;;
+		background) background="$value" ;;
+		*) echo "Warning: Unknown frontmatter key '$key' in $input_file" >&2 ;;
+		esac
+	done <<<"$frontmatter_text"
 
-  if [[ -z "$name" ]]; then
-    echo "Error: Missing 'name' in frontmatter: $input_file" >&2
-    continue
-  fi
-  if [[ -z "$description" ]]; then
-    echo "Error: Missing 'description' in frontmatter: $input_file" >&2
-    continue
-  fi
+	if [[ -z "$name" ]]; then
+		echo "Error: Missing 'name' in frontmatter: $input_file" >&2
+		continue
+	fi
+	if [[ -z "$description" ]]; then
+		echo "Error: Missing 'description' in frontmatter: $input_file" >&2
+		continue
+	fi
 
-  # Extract body (everything after closing ---)
-  body=$(tail -n +"$((second_delim + 1))" "$input_file")
-  # Strip leading empty lines
-  body=$(printf '%s' "$body" | sed '/./,$!d')
+	# Extract body (everything after closing ---)
+	body=$(tail -n +"$((second_delim + 1))" "$input_file")
+	# Strip leading empty lines
+	body=$(printf '%s' "$body" | sed '/./,$!d')
 
-  # Build Constraints section
-  constraints_section=""
-  if [[ "$permission_mode" == "plan" || -n "$tools" ]]; then
-    constraints_section="## Constraints"$'\n'$'\n'
-    if [[ "$permission_mode" == "plan" ]]; then
-      constraints_section+="- You are limited to READ-ONLY operations. Do not modify any files."$'\n'
-    fi
-    if [[ -n "$tools" ]]; then
-      constraints_section+="- Equivalent tool restrictions: ${tools} only."$'\n'
-    fi
-  fi
+	# Build Constraints section
+	constraints_section=""
+	if [[ "$permission_mode" == "plan" || -n "$tools" ]]; then
+		constraints_section="## Constraints"$'\n'$'\n'
+		if [[ "$permission_mode" == "plan" ]]; then
+			constraints_section+="- You are limited to READ-ONLY operations. Do not modify any files."$'\n'
+		fi
+		if [[ -n "$tools" ]]; then
+			constraints_section+="- Equivalent tool restrictions: ${tools} only."$'\n'
+		fi
+	fi
 
-  # Inject Constraints before the first ## heading in body
-  if [[ -n "$constraints_section" ]]; then
-    first_heading_line=$(printf '%s' "$body" | grep -n '^## ' | head -1 | cut -d: -f1)
-    if [[ -n "$first_heading_line" ]]; then
-      opening=$(printf '%s' "$body" | head -n "$((first_heading_line - 1))")
-      rest=$(printf '%s' "$body" | tail -n +"$first_heading_line")
-      body="${opening}"$'\n'$'\n'"${constraints_section}"$'\n'"${rest}"
-    else
-      body="${constraints_section}"$'\n'"${body}"
-    fi
-  fi
+	# Inject Constraints before the first ## heading in body
+	if [[ -n "$constraints_section" ]]; then
+		first_heading_line=$(printf '%s' "$body" | grep -n '^## ' | head -1 | cut -d: -f1)
+		if [[ -n "$first_heading_line" ]]; then
+			opening=$(printf '%s' "$body" | head -n "$((first_heading_line - 1))")
+			rest=$(printf '%s' "$body" | tail -n +"$first_heading_line")
+			body="${opening}"$'\n'$'\n'"${constraints_section}"$'\n'"${rest}"
+		else
+			body="${constraints_section}"$'\n'"${body}"
+		fi
+	fi
 
-  # Map sandbox_mode
-  sandbox_line=""
-  if [[ "$permission_mode" == "plan" ]]; then
-    sandbox_line='sandbox_mode = "read-only"'
-  fi
+	# Map sandbox_mode
+	sandbox_line=""
+	if [[ "$permission_mode" == "plan" ]]; then
+		sandbox_line='sandbox_mode = "read-only"'
+	fi
 
-  # Build header comments
-  short_desc=$(printf '%s' "$description" | sed 's/\. .*//' | cut -c1-80)
-  source_basename=$(basename "$input_file")
+	# Build header comments
+	short_desc=$(printf '%s' "$description" | sed 's/\. .*//' | cut -c1-80)
+	source_basename=$(basename "$input_file")
 
-  # Build comment block
-  comments="# ${name}: ${short_desc}"$'\n'
-  comments+="# Claude/Cursor equivalent: agents/${source_basename}"
+	# Build comment block
+	comments="# ${name}: ${short_desc}"$'\n'
+	comments+="# Claude/Cursor equivalent: agents/${source_basename}"
 
-  if [[ -n "$memory" ]]; then
-    comments+=$'\n'"# Note: Claude/Cursor version has memory=${memory} for cross-session learning."
-    comments+=$'\n'"# Codex CLI does not support agent-level memory, so memory instructions are omitted."
-  fi
-  if [[ -n "$max_turns" ]]; then
-    comments+=$'\n'"# Note: Claude/Cursor version has maxTurns=${max_turns}. Codex CLI does not support this."
-  fi
-  if [[ -n "$background" ]]; then
-    comments+=$'\n'"# Note: Claude/Cursor version has background=${background}. Codex CLI does not support this."
-  fi
+	if [[ -n "$memory" ]]; then
+		comments+=$'\n'"# Note: Claude/Cursor version has memory=${memory} for cross-session learning."
+		comments+=$'\n'"# Codex CLI does not support agent-level memory, so memory instructions are omitted."
+	fi
+	if [[ -n "$max_turns" ]]; then
+		comments+=$'\n'"# Note: Claude/Cursor version has maxTurns=${max_turns}. Codex CLI does not support this."
+	fi
+	if [[ -n "$background" ]]; then
+		comments+=$'\n'"# Note: Claude/Cursor version has background=${background}. Codex CLI does not support this."
+	fi
 
-  # Escape triple quotes in body
-  safe_body=$(printf '%s' "$body" | sed 's/"""/""\\"/g')
+	# Escape triple quotes in body
+	safe_body=$(printf '%s' "$body" | sed 's/"""/""\\"/g')
 
-  # Assemble TOML
-  assemble_toml() {
-    printf '%s\n' "$comments"
-    printf '\n'
-    printf 'model = "%s"\n' "gpt-5.3-codex"
-    printf 'model_reasoning_effort = "%s"\n' "$reasoning_effort"
-    if [[ -n "$sandbox_line" ]]; then
-      printf '%s\n' "$sandbox_line"
-    fi
-    printf '\n'
-    printf 'developer_instructions = """\n'
-    printf '%s\n' "$safe_body"
-    printf '"""\n'
-  }
+	# Assemble TOML
+	assemble_toml() {
+		printf '%s\n' "$comments"
+		printf '\n'
+		printf 'model = "%s"\n' "gpt-5.3-codex"
+		printf 'model_reasoning_effort = "%s"\n' "$reasoning_effort"
+		if [[ -n "$sandbox_line" ]]; then
+			printf '%s\n' "$sandbox_line"
+		fi
+		printf '\n'
+		printf 'developer_instructions = """\n'
+		printf '%s\n' "$safe_body"
+		printf '"""\n'
+	}
 
-  # Output
-  if [[ $dry_run -eq 1 ]]; then
-    assemble_toml
-    if [[ -n "$memory" ]]; then
-      echo "" >&2
-      echo "[REVIEW NEEDED] Source had memory=${memory}. Memory-related sections may need manual removal from developer_instructions." >&2
-    fi
-    success_count=$((success_count + 1))
-    continue
-  fi
+	# Output
+	if [[ $dry_run -eq 1 ]]; then
+		assemble_toml
+		if [[ -n "$memory" ]]; then
+			echo "" >&2
+			echo "[REVIEW NEEDED] Source had memory=${memory}. Memory-related sections may need manual removal from developer_instructions." >&2
+		fi
+		success_count=$((success_count + 1))
+		continue
+	fi
 
-  mkdir -p "$output_dir"
-  target_file="${output_dir}/${name}.toml"
+	mkdir -p "$output_dir"
+	target_file="${output_dir}/${name}.toml"
 
-  if [[ -e "$target_file" && $force_overwrite -ne 1 ]]; then
-    if prompt_from_tty answer "File exists: ${target_file}. Overwrite? [y/N]: "; then
-      case "$answer" in
-        y|Y|yes|YES) ;;
-        *)
-          echo "Skipped: $target_file"
-          continue
-          ;;
-      esac
-    else
-      echo "Error: target file already exists: ${target_file}" >&2
-      echo "Use --force in non-interactive mode." >&2
-      continue
-    fi
-  fi
+	if [[ -e "$target_file" && $force_overwrite -ne 1 ]]; then
+		if prompt_from_tty answer "File exists: ${target_file}. Overwrite? [y/N]: "; then
+			case "$answer" in
+			y | Y | yes | YES) ;;
+			*)
+				echo "Skipped: $target_file"
+				continue
+				;;
+			esac
+		else
+			echo "Error: target file already exists: ${target_file}" >&2
+			echo "Use --force in non-interactive mode." >&2
+			continue
+		fi
+	fi
 
-  assemble_toml > "$target_file"
-  echo "Created: $target_file"
+	assemble_toml >"$target_file"
+	echo "Created: $target_file"
 
-  if [[ -n "$memory" ]]; then
-    echo "  WARNING: Source had memory=${memory}. Review developer_instructions for memory-related content to remove." >&2
-  fi
+	if [[ -n "$memory" ]]; then
+		echo "  WARNING: Source had memory=${memory}. Review developer_instructions for memory-related content to remove." >&2
+	fi
 
-  success_count=$((success_count + 1))
+	success_count=$((success_count + 1))
 done
 
 if [[ $success_count -eq 0 ]]; then
-  echo "Error: No files were converted." >&2
-  exit 1
+	echo "Error: No files were converted." >&2
+	exit 1
 fi

--- a/skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh
+++ b/skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'EOF'
+	cat <<'EOF'
 Usage:
   export_blog_idea_draft.sh --slug <kebab-case> [--date <YYYY-MM-DD>] [--output-dir <dir>] [--force]
 
@@ -15,20 +15,20 @@ EOF
 }
 
 prompt_from_tty() {
-  local __var_name="$1"
-  local __prompt="$2"
-  local __value=""
+	local __var_name="$1"
+	local __prompt="$2"
+	local __value=""
 
-  if [[ ! -t 0 && ! -t 1 ]]; then
-    return 1
-  fi
+	if [[ ! -t 0 && ! -t 1 ]]; then
+		return 1
+	fi
 
-  if read -r -p "$__prompt" __value < /dev/tty; then
-    printf -v "$__var_name" "%s" "$__value"
-    return 0
-  fi
+	if read -r -p "$__prompt" __value </dev/tty; then
+		printf -v "$__var_name" "%s" "$__value"
+		return 0
+	fi
 
-  return 1
+	return 1
 }
 
 slug=""
@@ -37,87 +37,86 @@ output_dir=""
 force_overwrite="0"
 
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --slug)
-      slug="${2:-}"
-      shift 2
-      ;;
-    --date)
-      draft_date="${2:-}"
-      shift 2
-      ;;
-    --output-dir)
-      output_dir="${2:-}"
-      shift 2
-      ;;
-    --force)
-      force_overwrite="1"
-      shift
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 1
-      ;;
-  esac
+	case "$1" in
+	--slug)
+		slug="${2:-}"
+		shift 2
+		;;
+	--date)
+		draft_date="${2:-}"
+		shift 2
+		;;
+	--output-dir)
+		output_dir="${2:-}"
+		shift 2
+		;;
+	--force)
+		force_overwrite="1"
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
 done
 
 if [[ -z "$slug" ]]; then
-  echo "Error: --slug is required." >&2
-  usage >&2
-  exit 1
+	echo "Error: --slug is required." >&2
+	usage >&2
+	exit 1
 fi
 
 if [[ ! "$slug" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
-  echo "Error: slug must be kebab-case ASCII (e.g. my-post-title)." >&2
-  exit 1
+	echo "Error: slug must be kebab-case ASCII (e.g. my-post-title)." >&2
+	exit 1
 fi
 
 if [[ -z "$draft_date" ]]; then
-  draft_date="$(date +%F)"
+	draft_date="$(date +%F)"
 fi
 
 if [[ -z "$output_dir" ]]; then
-  output_dir="${BLOG_IDEA_DRAFT_EXPORT_DIR:-}"
+	output_dir="${BLOG_IDEA_DRAFT_EXPORT_DIR:-}"
 fi
 
 if [[ -z "$output_dir" ]]; then
-  default_dir="$HOME/workspace/hodalog-hugo/docs/idea"
-  if prompt_from_tty user_dir "Output directory (default: ${default_dir}): "; then
-    output_dir="${user_dir:-$default_dir}"
-  else
-    echo "Error: output directory is not set." >&2
-    echo "Set BLOG_IDEA_DRAFT_EXPORT_DIR or pass --output-dir." >&2
-    echo "In skill execution, ask the user for a directory and pass --output-dir." >&2
-    exit 1
-  fi
+	default_dir="$HOME/workspace/hodalog-hugo/docs/idea"
+	if prompt_from_tty user_dir "Output directory (default: ${default_dir}): "; then
+		output_dir="${user_dir:-$default_dir}"
+	else
+		echo "Error: output directory is not set." >&2
+		echo "Set BLOG_IDEA_DRAFT_EXPORT_DIR or pass --output-dir." >&2
+		echo "In skill execution, ask the user for a directory and pass --output-dir." >&2
+		exit 1
+	fi
 fi
 
 mkdir -p "$output_dir"
 target_file="${output_dir}/${draft_date}_${slug}.md"
 
 if [[ -e "$target_file" && "$force_overwrite" != "1" ]]; then
-  if prompt_from_tty answer "File exists: ${target_file}. Overwrite? [y/N]: "; then
-    case "$answer" in
-      y|Y|yes|YES)
-        ;;
-      *)
-        echo "Canceled."
-        exit 1
-        ;;
-    esac
-  else
-    echo "Error: target file already exists: ${target_file}" >&2
-    echo "Use --force in non-interactive mode." >&2
-    exit 1
-  fi
+	if prompt_from_tty answer "File exists: ${target_file}. Overwrite? [y/N]: "; then
+		case "$answer" in
+		y | Y | yes | YES) ;;
+		*)
+			echo "Canceled."
+			exit 1
+			;;
+		esac
+	else
+		echo "Error: target file already exists: ${target_file}" >&2
+		echo "Use --force in non-interactive mode." >&2
+		exit 1
+	fi
 fi
 
-cat > "$target_file"
+cat >"$target_file"
 
 markdownlint-cli2 --fix "$target_file"
 

--- a/skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh
+++ b/skills/blog-idea-draft-export/scripts/export_blog_idea_draft.sh
@@ -102,6 +102,7 @@ target_file="${output_dir}/${draft_date}_${slug}.md"
 
 if [[ -e "$target_file" && "$force_overwrite" != "1" ]]; then
 	if prompt_from_tty answer "File exists: ${target_file}. Overwrite? [y/N]: "; then
+		# shellcheck disable=SC2154
 		case "$answer" in
 		y | Y | yes | YES) ;;
 		*)


### PR DESCRIPTION
## 実装経緯の説明
シェルスクリプトの品質をCIで自動チェックするため、lint.ymlにshell-lintジョブを追加する。

## チケット
N/A

## 補足
### 主な変更内容
- `shfmt -d .` によるフォーマットチェックを追加
- `shellcheck ./**/*.sh` による静的解析を追加
- 既存の markdownlint / prettier と並列で動く独立ジョブとして追加

### 技術的な詳細
- shfmt は ubuntu-latest のプリインストール Go 環境を使い `go install mvdan.cc/sh/v3/cmd/shfmt@latest` でインストール
- shellcheck は ubuntu-latest にプリインストール済みのためそのまま利用
- actions/checkout@v6, 既存ジョブと同じバージョンを使用

### 確認事項
- CI が正常に通ること
- リポジトリ内の `.sh` ファイルが shfmt / shellcheck のチェックをパスすること
- `shellcheck ./**/*.sh` の glob 展開が期待通りに動作すること（globstar 無効時はサブディレクトリが検出されない可能性あり）