### PR TITLE
Add prettier hook for Claude and Cursor

### DIFF
--- a/settings/claude/hooks/prettier.sh
+++ b/settings/claude/hooks/prettier.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+FILE_PATH=$(echo "$CLAUDE_TOOL_OUTPUT" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('filePath', ''))
+" 2>/dev/null)
+
+case "$FILE_PATH" in
+*.html | *.css | *.js | *.ts | *.json | *.yaml | *.yml)
+	prettier --write "$FILE_PATH"
+	;;
+esac

--- a/settings/claude/settings.json
+++ b/settings/claude/settings.json
@@ -47,7 +47,8 @@
         "hooks": [
           { "type": "command", "command": ".claude/hooks/goimports.sh" },
           { "type": "command", "command": ".claude/hooks/markdown-format.sh" },
-          { "type": "command", "command": ".claude/hooks/shfmt.sh" }
+          { "type": "command", "command": ".claude/hooks/shfmt.sh" },
+          { "type": "command", "command": ".claude/hooks/prettier.sh" }
         ]
       }
     ]

--- a/settings/cursor/hooks.json
+++ b/settings/cursor/hooks.json
@@ -2,15 +2,10 @@
   "version": 1,
   "hooks": {
     "afterFileEdit": [
-      {
-        "command": ".cursor/hooks/goimports.sh"
-      },
-      {
-        "command": ".cursor/hooks/markdown-format.sh"
-      },
-      {
-        "command": ".cursor/hooks/shfmt.sh"
-      }
+      { "command": ".cursor/hooks/goimports.sh" },
+      { "command": ".cursor/hooks/markdown-format.sh" },
+      { "command": ".cursor/hooks/shfmt.sh" },
+      { "command": ".cursor/hooks/prettier.sh" }
     ]
   }
 }

--- a/settings/cursor/hooks/prettier.sh
+++ b/settings/cursor/hooks/prettier.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+FILE_PATH=$(python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('file_path', ''))
+")
+
+case "$FILE_PATH" in
+*.html | *.css | *.js | *.ts | *.json | *.yaml | *.yml)
+	prettier --write "$FILE_PATH"
+	;;
+esac


### PR DESCRIPTION
## 実装経緯の説明
HTML, CSS, JS, TS, JSON, YAML ファイル編集時に prettier による自動フォーマットを適用し、コードスタイルの一貫性を保つためのフックを追加。

## チケット
N/A

## 補足
### 主な変更内容
- Claude 用 `prettier.sh` フックスクリプトを新規追加
- Cursor 用 `prettier.sh` フックスクリプトを新規追加
- `settings/claude/settings.json` に prettier フックを登録
- `settings/cursor/hooks.json` に prettier フックを登録（フォーマットも整理）

### 技術的な詳細
- Claude 版は `CLAUDE_TOOL_OUTPUT` 環境変数から `filePath` を取得
- Cursor 版は stdin から `file_path` を取得
- 対象拡張子: `.html`, `.css`, `.js`, `.ts`, `.json`, `.yaml`, `.yml`
- `case` 文で拡張子をマッチさせ、該当ファイルのみ `prettier --write` を実行

### 確認事項
- prettier がインストールされた環境で各フックが正しく動作すること
- 既存フック（goimports, markdown-format, shfmt）との共存に問題がないこと